### PR TITLE
write to stderr

### DIFF
--- a/c/lib/cameras.c
+++ b/c/lib/cameras.c
@@ -55,11 +55,11 @@ static int stream_process(packet_stream *strm, uint8_t *pkt, int len)
 	int datalen = len - sizeof(*hdr);
 
 	if (hdr->magic[0] != 'R' || hdr->magic[1] != 'B') {
-		printf("[Stream %02x] Invalid magic %02x%02x\n", strm->flag, hdr->magic[0], hdr->magic[1]);
+		err("[Stream %02x] Invalid magic %02x%02x\n", strm->flag, hdr->magic[0], hdr->magic[1]);
 		return 0;
 	}
 
-	//printf("[Stream %02x] %02x\n", strm->flag, hdr->flag);
+	dbg("[Stream %02x] %02x\n", strm->flag, hdr->flag);
 
 	uint8_t sof = strm->flag|1;
 	uint8_t mof = strm->flag|2;
@@ -68,7 +68,7 @@ static int stream_process(packet_stream *strm, uint8_t *pkt, int len)
 	// sync if required, dropping packets until SOF
 	if (!strm->synced) {
 		if (hdr->flag != sof) {
-			//printf("[Stream %02x] not synced yet...\n", strm->flag);
+			dbg("[Stream %02x] not synced yet...\n", strm->flag);
 			return 0;
 		}
 		strm->synced = 1;
@@ -83,9 +83,9 @@ static int stream_process(packet_stream *strm, uint8_t *pkt, int len)
 	// handle lost packets
 	if (strm->seq != hdr->seq) {
 		uint8_t lost = strm->seq - hdr->seq;
-		printf("[Stream %02x] lost %d packets\n", strm->flag, lost);
+		wrn("[Stream %02x] lost %d packets\n", strm->flag, lost);
 		if (lost > 5) {
-			printf("[Stream %02x] lost too many packets, resyncing...\n", strm->flag);
+			err("[Stream %02x] lost too many packets, resyncing...\n", strm->flag);
 			strm->synced = 0;
 			return 0;
 		}
@@ -106,7 +106,7 @@ static int stream_process(packet_stream *strm, uint8_t *pkt, int len)
 	if (!(strm->pkt_num == 0 && hdr->flag == sof) &&
 	    !(strm->pkt_num == strm->pkts_per_frame-1 && hdr->flag == eof) &&
 	    !(strm->pkt_num > 0 && strm->pkt_num < strm->pkts_per_frame-1 && hdr->flag == mof)) {
-		printf("[Stream %02x] Inconsistent flag %02x with %d packets in buf (%d total), resyncing...\n",
+		err("[Stream %02x] Inconsistent flag %02x with %d packets in buf (%d total), resyncing...\n",
 		       strm->flag, hdr->flag, strm->pkt_num, strm->pkts_per_frame);
 		strm->synced = 0;
 		return 0;
@@ -114,12 +114,12 @@ static int stream_process(packet_stream *strm, uint8_t *pkt, int len)
 
 	// copy data
 	if (datalen > strm->pkt_size) {
-		printf("[Stream %02x] Expected %d data bytes, but got %d. Dropping...\n", strm->flag, strm->pkt_size, datalen);
+		err("[Stream %02x] Expected %d data bytes, but got %d. Dropping...\n", strm->flag, strm->pkt_size, datalen);
 		return 0;
 	}
 
 	if (datalen != strm->pkt_size && hdr->flag != eof)
-		printf("[Stream %02x] Expected %d data bytes, but got only %d\n", strm->flag, strm->pkt_size, datalen);
+		dbg("[Stream %02x] Expected %d data bytes, but got only %d\n", strm->flag, strm->pkt_size, datalen);
 
 	uint8_t *dbuf = strm->buf + strm->pkt_num * strm->pkt_size;
 	memcpy(dbuf, data, datalen);
@@ -152,7 +152,7 @@ static void depth_process(freenect_device *dev, uint8_t *pkt, int len)
 	if (!got_frame)
 		return;
 
-	printf("GOT DEPTH FRAME %d/%d packets arrived, TS %08x\n",
+	dbg("GOT DEPTH FRAME %d/%d packets arrived, TS %08x\n",
 	       dev->depth_stream.valid_pkts, dev->depth_stream.pkts_per_frame, dev->depth_stream.timestamp);
 
 	int bitshift = 0;
@@ -178,7 +178,7 @@ static void rgb_process(freenect_device *dev, uint8_t *pkt, int len)
 	if (!got_frame)
 		return;
 
-	printf("GOT RGB FRAME %d/%d packets arrived, TS %08x\n", dev->rgb_stream.valid_pkts,
+	dbg("GOT RGB FRAME %d/%d packets arrived, TS %08x\n", dev->rgb_stream.valid_pkts,
 	       dev->rgb_stream.pkts_per_frame, dev->rgb_stream.timestamp);
 
 	uint8_t *rgb_frame = NULL;
@@ -271,7 +271,7 @@ static void send_init(freenect_device *dev)
 	struct cam_hdr *rhdr = (void*)ibuf;
 
 	ret = fnusb_control(&dev->usb_cam, 0x80, 0x06, 0x3ee, 0, ibuf, 0x12);
-	printf("First xfer: %d\n", ret);
+	dbg("First xfer: %d\n", ret);
 
 	chdr->magic[0] = 0x47;
 	chdr->magic[1] = 0x4d;
@@ -283,37 +283,38 @@ static void send_init(freenect_device *dev)
 		chdr->len = ip->cmdlen / 2;
 		memcpy(obuf+sizeof(*chdr), ip->cmddata, ip->cmdlen);
 		ret = fnusb_control(&dev->usb_cam, 0x40, 0, 0, 0, obuf, ip->cmdlen + sizeof(*chdr));
-		printf("CTL CMD %04x %04x = %d\n", chdr->cmd, chdr->tag, ret);
+		dbg("CTL CMD %04x %04x = %d\n", chdr->cmd, chdr->tag, ret);
 		do {
 			ret = fnusb_control(&dev->usb_cam, 0xc0, 0, 0, 0, ibuf, 0x200);
 		} while (ret == 0);
-		printf("CTL RES = %d\n", ret);
+		dbg("CTL RES = %d\n", ret);
 		if (rhdr->magic[0] != 0x52 || rhdr->magic[1] != 0x42) {
-			printf("Bad magic %02x %02x\n", rhdr->magic[0], rhdr->magic[1]);
+			wrn("Bad magic %02x %02x\n", rhdr->magic[0], rhdr->magic[1]);
 			continue;
 		}
 		if (rhdr->cmd != chdr->cmd) {
-			printf("Bad cmd %02x != %02x\n", rhdr->cmd, chdr->cmd);
+			wrn("Bad cmd %02x != %02x\n", rhdr->cmd, chdr->cmd);
 			continue;
 		}
 		if (rhdr->tag != chdr->tag) {
-			printf("Bad tag %04x != %04x\n", rhdr->tag, chdr->tag);
+			wrn("Bad tag %04x != %04x\n", rhdr->tag, chdr->tag);
 			continue;
 		}
 		if (rhdr->len != (ret-sizeof(*rhdr))/2) {
-			printf("Bad len %04x != %04x\n", rhdr->len, (int)(ret-sizeof(*rhdr))/2);
+			wrn("Bad len %04x != %04x\n", rhdr->len, (int)(ret-sizeof(*rhdr))/2);
 			continue;
 		}
 		if (rhdr->len != (ip->replylen/2) || memcmp(ibuf+sizeof(*rhdr), ip->replydata, ip->replylen)) {
-			printf("Expected: ");
+			wrn("Expected: ");
 			for (j=0; j<ip->replylen; j++) {
-				printf("%02x ", ip->replydata[j]);
+				fprintf(stderr, "%02x ", ip->replydata[j]);
 			}
-			printf("\nGot:      ");
+			fprintf(stderr, "\n");
+			wrn("\tGot:      ");
 			for (j=0; j<(rhdr->len*2); j++) {
-				printf("%02x ", ibuf[j+sizeof(*rhdr)]);
+				fprintf(stderr, "%02x ", ibuf[j+sizeof(*rhdr)]);
 			}
-			printf("\n");
+			fprintf(stderr, "\n");
 		}
 	}
 	dev->cam_inited = 1;
@@ -354,12 +355,12 @@ int freenect_start_rgb(freenect_device *dev)
 
 int freenect_stop_depth(freenect_device *dev)
 {
-	printf("%s NOT IMPLEMENTED YET\n", __FUNCTION__);
+	wrn("%s NOT IMPLEMENTED YET\n", __FUNCTION__);
 	return 0;
 }
 int freenect_stop_rgb(freenect_device *dev)
 {
-	printf("%s NOT IMPLEMENTED YET\n", __FUNCTION__);
+	wrn("%s NOT IMPLEMENTED YET\n", __FUNCTION__);
 	return 0;
 }
 

--- a/c/lib/freenect_internal.h
+++ b/c/lib/freenect_internal.h
@@ -53,6 +53,34 @@ struct _freenect_context {
 #define DEPTH_PKTS_PER_FRAME ((DEPTH_RAW_SIZE+DEPTH_PKTDSIZE-1)/DEPTH_PKTDSIZE)
 #define RGB_PKTS_PER_FRAME ((FRAME_PIX+RGB_PKTDSIZE-1)/RGB_PKTDSIZE)
 
+#define inf(...) \
+	do { \
+		fprintf(stderr, "INF: "); \
+		fprintf(stderr, __VA_ARGS__); \
+	} while(0)
+
+#define wrn(...) \
+	do { \
+		fprintf(stderr, "WRN: "); \
+		fprintf(stderr, __VA_ARGS__); \
+	} while(0)
+
+#define err(...) \
+	do { \
+		fprintf(stderr, "ERR: "); \
+		fprintf(stderr, __VA_ARGS__); \
+	} while(0)
+
+#ifdef LIBFREENECT_DBG
+#define dbg(...) \
+	do { \
+		fprintf(stderr, "DBG: "); \
+		fprintf(stderr, __VA_ARGS__); \
+	} while(0)
+#else
+#define dbg(...)
+#endif
+
 typedef struct {
 	uint8_t flag;
 	int synced;

--- a/c/lib/usb_libusb10.c
+++ b/c/lib/usb_libusb10.c
@@ -88,7 +88,7 @@ static void iso_callback(struct libusb_transfer *xfer)
 		}
 		libusb_submit_transfer(xfer);
 	} else {
-		printf("Xfer error: %d\n", xfer->status);
+		err("Xfer error: %d\n", xfer->status);
 	}
 }
 
@@ -107,7 +107,7 @@ int fnusb_start_iso(fnusb_dev *dev, fnusb_isoc_stream *strm, fnusb_iso_cb cb, in
 	uint8_t *bufp = strm->buffer;
 
 	for (i=0; i<xfers; i++) {
-		printf("Creating EP %02x transfer #%d\n", ep, i);
+		dbg("Creating EP %02x transfer #%d\n", ep, i);
 		strm->xfers[i] = libusb_alloc_transfer(pkts);
 
 		libusb_fill_iso_transfer(strm->xfers[i], dev->dev, ep, bufp, pkts * len, pkts, iso_callback, strm, 0);
@@ -116,7 +116,7 @@ int fnusb_start_iso(fnusb_dev *dev, fnusb_isoc_stream *strm, fnusb_iso_cb cb, in
 
 		ret = libusb_submit_transfer(strm->xfers[i]);
 		if (ret < 0)
-			printf("Failed to submit xfer %d: %d\n", i, ret);
+			wrn("Failed to submit xfer %d: %d\n", i, ret);
 
 		bufp += pkts*len;
 	}


### PR DESCRIPTION
This change moves all console messages to stderr.  This way, calling applications can pipe data to/from stdin/stdout without the library interfering.  
