### PR TITLE
Synchronous python binding, uses the current python binding

### DIFF
--- a/c/python/demo_synch.py
+++ b/c/python/demo_synch.py
@@ -1,0 +1,53 @@
+from freenect_synch import get_depth, get_rgb
+import cv  
+import numpy as np
+
+
+def array2cv(a):
+  dtype2depth = {
+        'uint8':   cv.IPL_DEPTH_8U,
+        'int8':    cv.IPL_DEPTH_8S,
+        'uint16':  cv.IPL_DEPTH_16U,
+        'int16':   cv.IPL_DEPTH_16S,
+        'int32':   cv.IPL_DEPTH_32S,
+        'float32': cv.IPL_DEPTH_32F,
+        'float64': cv.IPL_DEPTH_64F,
+    }
+  try:
+    nChannels = a.shape[2]
+  except:
+    nChannels = 1
+  cv_im = cv.CreateImageHeader((a.shape[1],a.shape[0]),
+          dtype2depth[str(a.dtype)],
+          nChannels)
+  cv.SetData(cv_im, a.tostring(),
+             a.dtype.itemsize*nChannels*a.shape[1])
+  return cv_im
+  
+def doloop():
+    cv.NamedWindow('depth')
+    cv.NamedWindow('rgb')
+    global depth, rgb
+    while True:
+        # Get a fresh frame
+        depth, rgb = get_depth(), get_rgb()
+        
+        # Build a two panel color image
+        d3 = np.dstack((depth,depth,depth)).astype(np.uint8)
+        da = np.hstack((d3,rgb))
+        
+        # Simple Downsample
+        cv.ShowImage('both',array2cv(da[::2,::2,::-1]))
+        cv.WaitKey(5)
+        
+doloop()
+
+"""
+IPython usage:
+ ipython
+ [1]: run -i demo_bgf
+ #<ctrl -c>  (to interrupt the loop)
+ [2]: %timeit -n100 QueryDepth(),QueryRGB() # profile the kinect capture
+
+"""
+

--- a/c/python/freenect_synch.py
+++ b/c/python/freenect_synch.py
@@ -1,0 +1,93 @@
+#
+# Copyright (c) 2010 Andrew Miller (amiller@dappervision.com)
+#
+# This code is licensed to you under the terms of the Apache License, version
+# 2.0, or, at your option, the terms of the GNU General Public License,
+# version 2.0. See the APACHE20 and GPL2 files for the text of the licenses,
+# or the following URLs:
+# http://www.apache.org/licenses/LICENSE-2.0
+# http://www.gnu.org/licenses/gpl-2.0.txt
+#
+# If you redistribute this file in source form, modified or unmodified, you
+# may:
+#   1) Leave this header intact and distribute it under the same terms,
+#      accompanying it with the APACHE20 and GPL20 files, or
+#   2) Delete the Apache 2.0 clause and accompany it with the GPL2 file, or
+#   3) Delete the GPL v2 clause and accompany it with the APACHE20 file
+# In all cases you must keep the copyright notice intact and include a copy
+# of the CONTRIB file.
+#
+# Binary distributions must follow the binary distribution requirements of
+# either License.
+
+
+# The point of this script is to provide a 'synchronous' interface to the kinect,
+# like with OpenCV. It works by having a background thread pump the kinect events
+# and handle the callbacks. Ask for a new frame by calling get_rgb() or get_depth().
+
+import freenect
+import numpy as np
+from threading import Condition, Thread
+
+depthcond = Condition()
+rgbcond = Condition()
+depthqueue = []
+rgbqueue = []
+
+# If we get a new frame, put it in the queue
+def _depth_cb(dev, string, ts):
+  global depthqueue
+  with depthcond:
+    depthqueue = [string]
+    depthcond.notify()
+
+# If we get a new frame, put it in the queue
+def _rgb_cb(dev, string, ts):
+  global rgbqueue
+  with rgbcond:
+    rgbqueue = [string]
+    rgbcond.notify()
+
+depth_cb = freenect.depth_cb_string_factory(_depth_cb)
+rgb_cb = freenect.rgb_cb_string_factory(_rgb_cb)
+
+def get_depth():
+  """Grabs a new depth frame, blocking until the background thread provides one.
+  
+     Returns:
+       a numpy array, with shape: (480,640), dtype: np.uint16
+  """
+  global depthqueue
+  with depthcond:
+    while not depthqueue:
+      depthcond.wait(5)
+    string = depthqueue[0]
+    depthqueue = []
+  data = np.fromstring(string, dtype=np.uint16)
+  data.resize((480, 640))
+  return data
+
+def get_rgb():
+  """Grabs a new RGB frame, blocking until the background thread provides one.
+  
+     Returns:
+       a numpy array, with shape: (480,640,3), dtype: np.uint8
+  """
+  global rgbqueue
+  with rgbcond:
+    while not rgbqueue:
+      rgbcond.wait(5)
+    string = rgbqueue[0]
+    rgbqueue = []
+  data = np.fromstring(string, dtype=np.uint8)
+  data.resize((480,640,3))
+  return data
+  
+
+# The first time around: start a background thread to connect to run freenect. 
+try:
+  loopthread == ''
+except:
+  loopthread = Thread(target=freenect.runloop,kwargs=dict(depth=depth_cb,rgb=rgb_cb))
+  loopthread.start()
+  


### PR DESCRIPTION
This is a small wrapper for the current python binding that provides a simple synchronous interface: get_depth() and get_rgb(). 

It works by having a background thread to call the runloop() of the current python binding.

This kind of interface is more like OpenCV's capture objects, and it's more convenient for prototyping with ipython.
