### PR TITLE
cmake: install pkg-config file on linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,3 +29,10 @@ target_link_libraries (freenectstatic ${LIBUSB_1_LIBRARIES})
 # Install the header file
 install (FILES "../include/libfreenect.h" "../include/libfreenect.hpp"
   DESTINATION ${PROJECT_INCLUDE_INSTALL_DIR})
+
+IF(UNIX AND NOT APPLE)
+  # Produce a pkg-config file for linking against the shared lib
+  configure_file ("libfreenect.pc.in" "libfreenect.pc" @ONLY)
+  install (FILES "${CMAKE_CURRENT_BINARY_DIR}/libfreenect.pc"
+    DESTINATION "${PROJECT_LIBRARY_INSTALL_DIR}/pkgconfig")
+ENDIF()

--- a/src/libfreenect.pc.in
+++ b/src/libfreenect.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+	
+Name: @CMAKE_PROJECT_NAME@
+Description: Interface to the Microsoft Kinect sensor device.
+Requires: libusb-1.0
+Version: @PROJECT_APIVER@
+Libs: -L${libdir} -lfreenect
+Cflags: -I${includedir}/libfreenect


### PR DESCRIPTION
This patch adds a libfreenect.pc.in and configures and installs it to PROJECT_LIBRARY_INSTALL_DIR/pkgconfig on Linux.

Compiling against libfreenect is then as easy as:

gcc $(pkg-config --cflags --libs libfreenect) -o mydemo -c mydemo.c
