### PR TITLE
Fixed fakenect to use new buffers, now allow record to be faked out by fakenect (I heard you like recordings, so now you can record what you record while you record your recordings) and made some minor Python readme tweaks

### DIFF
--- a/wrappers/python/README
+++ b/wrappers/python/README
@@ -42,3 +42,8 @@ LD_PRELOAD="/usr/local/lib/fakenect/libfreenect.so" FAKENECT_PATH="../../build/u
 The synchronous calls are performed using the c_sync wrapper (no threading is done in Python).
 Run this for an example
 ./demo_cv_sync.py
+
+
+Troubleshooting
+- If you get "/usr/bin/ld: cannot find -lfreenect", then it can't find the library.  It looks in '/usr/local/lib' '/usr/local/lib64' along with anything set in LD_LIBRARY_PATH.  You probably need to do sudo make install in the build dir.  If it puts it in a directory that isn't one of those 2 let me know and I'll add it as another place to look.
+- If you get "libusb couldn't open USB device /dev/bus/usb/002/005: Permission denied. libusb requires write access to USB device nodes. Could not open camera: -3 Error: Cannot get device", then you are having a permissions problem.  You can run the program with root by doing "sudo ./your_cool_demo_here" or you can follow the udev rules in the project root.


### PR DESCRIPTION
1. Fixed fakenect to support the new set_rgb/depth_buffer stuff which fixes support for glview
2. Made fakenect use internal linkage for all internal stuff, this now allows you to do the craziest test of running record to get a dump, then using fakenect to replay the dump to record again.
3. Minor Python readme fix for troubleshooting.
