### PR TITLE
fixed libfreenect.hpp & example for the C++ header

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,11 +3,13 @@
 ######################################################################################
 
 add_executable(glview glview.c)
+add_executable(cppview cppview.cpp)
 
 # Mac just has everything already
 if(APPLE)
   set(CMAKE_EXE_LINKER_FLAGS "-framework OpenGL -framework GLUT")
   target_link_libraries(glview freenect)
+  target_link_libraries(cppview freenect)
 # Linux, not so much
 else()
   find_package(Threads REQUIRED)
@@ -15,7 +17,11 @@ else()
   find_package(GLUT REQUIRED)
   include_directories(${OPENGL_INCLUDE_DIRS} ${GLUT_INCLUDE_DIRS} ${USB_INCLUDE_DIRS})
   target_link_libraries(glview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} m)
+  target_link_libraries(cppview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} m)
 endif()
 
 install (TARGETS glview
+  DESTINATION bin)
+
+install (TARGETS cppview
   DESTINATION bin)

--- a/examples/cppview.cpp
+++ b/examples/cppview.cpp
@@ -1,0 +1,329 @@
+/*This file is part of the OpenKinect Project. http://www.openkinect.org
+
+Copyright (c) 2010 individual OpenKinect contributors. See the CONTRIB
+file for details.
+
+This code is licensed to you under the terms of the Apache License,
+version 2.0, or, at your option, the terms of the GNU General Public
+License, version 2.0. See the APACHE20 and GPL2 files for the text of
+the licenses, or the following URLs:
+http://www.apache.org/licenses/LICENSE-2.0
+http://www.gnu.org/licenses/gpl-2.0.txt
+
+If you redistribute this file in source form, modified or unmodified,
+you may:
+
+- Leave this header intact and distribute it under the same terms,
+  accompanying it with the APACHE20 and GPL2 files, or
+- Delete the Apache 2.0 clause and accompany it with the GPL2 file, or
+- Delete the GPL v2 clause and accompany it with the APACHE20 file
+
+In all cases you must keep the copyright notice intact and include a
+copy of the CONTRIB file.
+
+Binary distributions must follow the binary distribution requirements
+of either License.*/
+
+
+#include "libfreenect.hpp"
+#include <pthread.h>
+#include <stdio.h>
+#include <iostream>
+#include <string.h>
+#include <cmath>
+#include <vector>
+
+#if defined(__APPLE__)
+#include <GLUT/glut.h>
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
+#else
+#include <GL/glut.h>
+#include <GL/gl.h>
+#include <GL/glu.h>
+#endif
+
+
+class Mutex {
+  public:
+	Mutex() {
+		m_mutex=PTHREAD_MUTEX_INITIALIZER;
+	}
+	void lock() {
+		pthread_mutex_lock( &m_mutex );
+	}
+	void unlock() {
+		pthread_mutex_unlock( &m_mutex );
+	}
+  private:
+	pthread_mutex_t m_mutex;
+};
+
+/* thanks to Yoda---- from IRC */
+class MyFreenectDevice : public Freenect::FreenectDevice {
+  public:
+	MyFreenectDevice(freenect_context *_ctx, int _index)
+		: Freenect::FreenectDevice(_ctx, _index), m_buffer_depth(FREENECT_VIDEO_RGB_SIZE),m_buffer_video(FREENECT_VIDEO_RGB_SIZE), m_gamma(2048), m_new_rgb_frame(false), m_new_depth_frame(false)
+	{
+		for( unsigned int i = 0 ; i < 2048 ; i++) {
+			float v = i/2048.0;
+			v = std::pow(v, 3)* 6;
+			m_gamma[i] = v*6*256;
+		}
+	}
+	// Do not call directly even in child
+	void VideoCallback(void* _rgb, uint32_t timestamp) {
+		std::cout << "RGB callback" << std::endl;
+		m_rgb_mutex.lock();
+		uint8_t* rgb = static_cast<uint8_t*>(_rgb);
+		std::copy(rgb, rgb+FREENECT_VIDEO_RGB_SIZE, m_buffer_video.begin());
+		m_new_rgb_frame = true;
+		m_rgb_mutex.unlock();
+	};
+	// Do not call directly even in child
+	void DepthCallback(void* _depth, uint32_t timestamp) {
+		std::cout << "Depth callback" << std::endl;
+		m_depth_mutex.lock();
+		uint16_t* depth = static_cast<uint16_t*>(_depth);
+		for( unsigned int i = 0 ; i < FREENECT_FRAME_PIX ; i++) {
+			int pval = m_gamma[depth[i]];
+			int lb = pval & 0xff;
+			switch (pval>>8) {
+				case 0:
+					m_buffer_depth[3*i+0] = 255;
+					m_buffer_depth[3*i+1] = 255-lb;
+					m_buffer_depth[3*i+2] = 255-lb;
+					break;
+				case 1:
+					m_buffer_depth[3*i+0] = 255;
+					m_buffer_depth[3*i+1] = lb;
+					m_buffer_depth[3*i+2] = 0;
+					break;
+				case 2:
+					m_buffer_depth[3*i+0] = 255-lb;
+					m_buffer_depth[3*i+1] = 255;
+					m_buffer_depth[3*i+2] = 0;
+					break;
+				case 3:
+					m_buffer_depth[3*i+0] = 0;
+					m_buffer_depth[3*i+1] = 255;
+					m_buffer_depth[3*i+2] = lb;
+					break;
+				case 4:
+					m_buffer_depth[3*i+0] = 0;
+					m_buffer_depth[3*i+1] = 255-lb;
+					m_buffer_depth[3*i+2] = 255;
+					break;
+				case 5:
+					m_buffer_depth[3*i+0] = 0;
+					m_buffer_depth[3*i+1] = 0;
+					m_buffer_depth[3*i+2] = 255-lb;
+					break;
+				default:
+					m_buffer_depth[3*i+0] = 0;
+					m_buffer_depth[3*i+1] = 0;
+					m_buffer_depth[3*i+2] = 0;
+					break;
+			}
+		}
+		m_new_depth_frame = true;
+		m_depth_mutex.unlock();
+	}
+	bool getRGB(std::vector<uint8_t> &buffer) {
+		m_rgb_mutex.lock();
+		if(m_new_rgb_frame) {
+			buffer.swap(m_buffer_video);
+			m_new_rgb_frame = false;
+			m_rgb_mutex.unlock();
+			return true;
+		} else {
+			m_rgb_mutex.unlock();
+			return false;
+		}
+	}
+
+	bool getDepth(std::vector<uint8_t> &buffer) {
+		m_depth_mutex.lock();
+		if(m_new_depth_frame) {
+			buffer.swap(m_buffer_depth);
+			m_new_depth_frame = false;
+			m_depth_mutex.unlock();
+			return true;
+		} else {
+			m_depth_mutex.unlock();
+			return false;
+		}
+	}
+
+  private:
+	std::vector<uint8_t> m_buffer_depth;
+	std::vector<uint8_t> m_buffer_video;
+	std::vector<uint16_t> m_gamma;
+	Mutex m_rgb_mutex;
+	Mutex m_depth_mutex;
+	bool m_new_rgb_frame;
+	bool m_new_depth_frame;
+};
+
+Freenect::Freenect<MyFreenectDevice> freenect;
+MyFreenectDevice* device;
+
+GLuint gl_depth_tex;
+GLuint gl_rgb_tex;
+
+bool die;
+double freenect_angle(0);
+int got_frames(0),window(0);
+int g_argc;
+char **g_argv;
+
+void DrawGLScene()
+{
+	static std::vector<uint8_t> depth(640*480*4);
+	static std::vector<uint8_t> rgb(640*480*4);
+
+	device->getDepth(depth);
+	device->getRGB(rgb);
+
+	got_frames = 0;
+
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	glLoadIdentity();
+
+	glEnable(GL_TEXTURE_2D);
+
+	glBindTexture(GL_TEXTURE_2D, gl_depth_tex);
+	glTexImage2D(GL_TEXTURE_2D, 0, 3, 640, 480, 0, GL_RGB, GL_UNSIGNED_BYTE, &depth[0]);
+
+	glBegin(GL_TRIANGLE_FAN);
+	glColor4f(255.0f, 255.0f, 255.0f, 255.0f);
+	glTexCoord2f(0, 0); glVertex3f(0,0,0);
+	glTexCoord2f(1, 0); glVertex3f(640,0,0);
+	glTexCoord2f(1, 1); glVertex3f(640,480,0);
+	glTexCoord2f(0, 1); glVertex3f(0,480,0);
+	glEnd();
+
+	glBindTexture(GL_TEXTURE_2D, gl_rgb_tex);
+	glTexImage2D(GL_TEXTURE_2D, 0, 3, 640, 480, 0, GL_RGB, GL_UNSIGNED_BYTE, &rgb[0]);
+
+	glBegin(GL_TRIANGLE_FAN);
+	glColor4f(255.0f, 255.0f, 255.0f, 255.0f);
+	glTexCoord2f(0, 0); glVertex3f(640,0,0);
+	glTexCoord2f(1, 0); glVertex3f(1280,0,0);
+	glTexCoord2f(1, 1); glVertex3f(1280,480,0);
+	glTexCoord2f(0, 1); glVertex3f(640,480,0);
+	glEnd();
+
+	glutSwapBuffers();
+}
+
+void keyPressed(unsigned char key, int x, int y)
+{
+	/*  FreenectDeviceState::getState() doesnt really work as expected */
+	//double freenect_angle = device->getState().getTiltDegs();
+
+	if (key == 27) {
+		die = 1;
+		glutDestroyWindow(window);
+	}
+	if (key == 'w') {
+		freenect_angle++;
+		if (freenect_angle > 30) {
+			freenect_angle = 30;
+		}
+	}
+	if (key == 's') {
+		freenect_angle = 0;
+	}
+	if (key == 'x') {
+		freenect_angle--;
+		if (freenect_angle < -30) {
+			freenect_angle = -30;
+		}
+	}
+	if (key == '1') {
+		device->setLed(LED_GREEN);
+	}
+	if (key == '2') {
+		device->setLed(LED_RED);
+	}
+	if (key == '3') {
+		device->setLed(LED_YELLOW);
+	}
+	if (key == '4') {
+		device->setLed(LED_BLINK_YELLOW);
+	}
+	if (key == '5') {
+		device->setLed(LED_BLINK_GREEN);
+	}
+	if (key == '6') {
+		device->setLed(LED_BLINK_RED_YELLOW);
+	}
+	if (key == '0') {
+		device->setLed(LED_OFF);
+	}
+	device->setTiltDegrees(freenect_angle);
+}
+
+void ReSizeGLScene(int Width, int Height)
+{
+	glViewport(0,0,Width,Height);
+	glMatrixMode(GL_PROJECTION);
+	glLoadIdentity();
+	glOrtho (0, 1280, 480, 0, -1.0f, 1.0f);
+	glMatrixMode(GL_MODELVIEW);
+}
+
+void InitGL(int Width, int Height)
+{
+	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+	glClearDepth(1.0);
+	glDepthFunc(GL_LESS);
+	glDisable(GL_DEPTH_TEST);
+	glEnable(GL_BLEND);
+	glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	glShadeModel(GL_SMOOTH);
+	glGenTextures(1, &gl_depth_tex);
+	glBindTexture(GL_TEXTURE_2D, gl_depth_tex);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glGenTextures(1, &gl_rgb_tex);
+	glBindTexture(GL_TEXTURE_2D, gl_rgb_tex);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	ReSizeGLScene(Width, Height);
+}
+
+void *gl_threadfunc(void *arg)
+{
+	printf("GL thread\n");
+
+	glutInit(&g_argc, g_argv);
+
+	glutInitDisplayMode(GLUT_RGBA | GLUT_DOUBLE | GLUT_ALPHA | GLUT_DEPTH);
+	glutInitWindowSize(1280, 480);
+	glutInitWindowPosition(0, 0);
+
+	window = glutCreateWindow("LibFreenect");
+
+	glutDisplayFunc(&DrawGLScene);
+	glutIdleFunc(&DrawGLScene);
+	glutReshapeFunc(&ReSizeGLScene);
+	glutKeyboardFunc(&keyPressed);
+
+	InitGL(1280, 480);
+
+	glutMainLoop();
+
+	return NULL;
+}
+
+int main(int argc, char **argv) {
+	device = &freenect.createDevice(0);
+	device->startVideo();
+	device->startDepth();
+	gl_threadfunc(NULL);
+	device->stopVideo();
+	device->stopDepth();
+	return 0;
+}

--- a/include/libfreenect.hpp
+++ b/include/libfreenect.hpp
@@ -41,7 +41,7 @@ namespace Freenect {
 		const Noncopyable& operator=( const Noncopyable& );
 	};
 	
-	class FreenectDeviceState : Noncopyable {
+	class FreenectDeviceState {
 		friend class FreenectDevice;
 			FreenectDeviceState(freenect_raw_tilt_state *_state):
 				m_state(_state)


### PR DESCRIPTION
Fixed libfreenect.hpp: made FreenectDeviceState copyable
Added cppview.cpp to examples, as an example for the C++ header

Signed-off-by: Kai Ritterbusch kai.ritterbusch@gmx.de
Signed-off-by: Vincent Le Ligeour yoda-jm@users.sourceforge.net
