### PR TITLE
updates to libfreenect.hpp and cppview.cpp

### DIFF
--- a/wrappers/cpp/CMakeLists.txt
+++ b/wrappers/cpp/CMakeLists.txt
@@ -1,6 +1,8 @@
 INSTALL(FILES libfreenect.hpp
   DESTINATION include)
 
+IF(BUILD_EXAMPLES)
+
 set(CMAKE_C_FLAGS "-Wall")
 
 if (WIN32)
@@ -36,3 +38,5 @@ endif()
 
 install (TARGETS cppview
   DESTINATION bin)
+
+ENDIF()


### PR DESCRIPTION
libfreenect.hpp: 
- fixed compiler warning about initialization sequence
- changed std::map::operator[] to std::map::find(), the better replacement for at()
- removed throw statements from destructors
- added format switching support

cppview.cpp:
- added video format switching to example
