### PR TITLE
Fixed Homebrew Formula

### DIFF
--- a/platform/osx/homebrew/libusb-freenect.rb
+++ b/platform/osx/homebrew/libusb-freenect.rb
@@ -12,7 +12,7 @@ class LibusbFreenect <Formula
 
   def install
     system "./autogen.sh"
-    system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
+    system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking", "LDFLAGS=-framework IOKit -framework CoreFoundation"
     system "make install"
   end
 end


### PR DESCRIPTION
Please include my small patch to your homebrew formula for installing via Homebrew on OS X. The original Formula incorrectly omitted framework linkage to CoreFoundation and IOKit, which caused unresolved symbol errors via 'dlopen()' on OS X.

Thanks,
-Eric Monti
