### PR TITLE
CoreFoundation and IOKit LDFLAGS for homebrew

### DIFF
--- a/platform/osx/homebrew/libusb-freenect.rb
+++ b/platform/osx/homebrew/libusb-freenect.rb
@@ -12,7 +12,7 @@ class LibusbFreenect <Formula
 
   def install
     system "./autogen.sh"
-    system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
+    system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking", "LDFLAGS=-framework IOKit -framework CoreFoundation"
     system "make install"
   end
 end


### PR DESCRIPTION
Patch to add IOKit and CoreFoundation frameworks to LDFLAGS in the homebrew formula for OS X.

Sorry, this one includes sign-off.
