### PR TITLE
Introduce wrappers/python into cmake build framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ OPTION(BUILD_FAKENECT "Build fakenect mock library" ON)
 OPTION(BUILD_C_SYNC "Build c synchronous library" ON)
 OPTION(BUILD_CV "Build OpenCV wrapper" OFF)
 OPTION(BUILD_AS3_SERVER "Build the Actionscript 3 Server Example" OFF)
+OPTION(BUILD_PYTHON "Build Python extension" OFF)
 IF(PROJECT_OS_LINUX)
 	OPTION(BUILD_CPACK "Build an RPM or DEB using CPack" OFF)
 ENDIF(PROJECT_OS_LINUX)
@@ -125,6 +126,10 @@ ENDIF()
 
 IF(BUILD_AS3_SERVER)
   add_subdirectory(wrappers/actionscript)
+ENDIF()
+
+IF(BUILD_PYTHON)
+  add_subdirectory (wrappers/python)
 ENDIF()
 
 ######################################################################################

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -1,0 +1,34 @@
+######################################################################################
+# Python extension builder
+######################################################################################
+
+include(FindPythonInterp)
+include(FindPythonLibs)
+
+find_program(CYTHON_EXECUTABLE cython)
+
+# Figure out installation path
+execute_process(COMMAND
+  ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()"
+  OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# How to Cython the .pyx file
+add_custom_command(OUTPUT freenect.c
+  COMMAND ${CYTHON_EXECUTABLE} -o freenect.c "${CMAKE_CURRENT_SOURCE_DIR}/freenect.pyx")
+list(APPEND ADDITIONAL_MAKE_CLEAN_FILES freenect.c)
+
+# Compile the extension
+add_library(cython_freenect MODULE freenect.c)
+set_target_properties(cython_freenect PROPERTIES
+  PREFIX ""
+  OUTPUT_NAME "freenect"
+  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(cython_freenect freenect_sync)
+include_directories(${PYTHON_INCLUDE_PATH} ../c_sync/)
+
+# Install the extension
+install(TARGETS cython_freenect
+  DESTINATION ${PYTHON_SITE_PACKAGES})
+
+# TODO: decide on what to do with demo_ scripts and were to install
+#       them


### PR DESCRIPTION
Resubmission of 
My ignorance in cmake and ignorance of cmake in Cython bundled up and produced following patch to make Python wrapping a part of the complete build infrastructure.
