### PR TITLE
Syncfix

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_C_FLAGS "-Wall")
 if (WIN32)
   set_source_files_properties(glview.c PROPERTIES LANGUAGE CXX)
   set_source_files_properties(glpclview.c PROPERTIES LANGUAGE CXX)
+	set_source_files_properties(tiltdemo.c PROPERTIES LANGUAGE CXX)
 
   set(THREADS_USE_PTHREADS_WIN32 true)
   find_package(Threads REQUIRED)
@@ -18,6 +19,7 @@ add_executable(glview glview.c)
 
 if (BUILD_C_SYNC)
   add_executable(glpclview glpclview.c)
+	add_executable(tiltdemo tiltdemo.c)
 endif()
 
 # We need to include libfreenect_sync.h for glpclview
@@ -29,6 +31,7 @@ if(APPLE)
   target_link_libraries(glview freenect)
   if (BUILD_C_SYNC)
     target_link_libraries(glpclview freenect_sync)
+		target_link_libraries(tiltdemo freenect_sync)
   endif()
 # Linux, not so much
 else()
@@ -47,7 +50,9 @@ else()
 
   target_link_libraries(glview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
   if (BUILD_C_SYNC)
-    target_link_libraries(glpclview freenect_sync ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
+    target_link_libraries(glpclview freenect_sync ${OPENGL_LIBRARIES} ${GLUT_LIBRARY}
+ ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
+		target_link_libraries(tiltdemo freenect_sync ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
   endif()
 endif()
 
@@ -56,6 +61,6 @@ install (TARGETS glview
   DESTINATION bin)
 
 if (BUILD_C_SYNC)
-  install (TARGETS glpclview
+  install (TARGETS glpclview tiltdemo
     DESTINATION bin)
 endif()

--- a/examples/tiltdemo.c
+++ b/examples/tiltdemo.c
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the OpenKinect Project. http://www.openkinect.org
+ *
+ * Copyright (c) 2010 individual OpenKinect contributors. See the CONTRIB file
+ * for details.
+ *
+ * Andrew Miller <amiller@dappervision.com>
+ *
+ * This code is licensed to you under the terms of the Apache License, version
+ * 2.0, or, at your option, the terms of the GNU General Public License,
+ * version 2.0. See the APACHE20 and GPL2 files for the text of the licenses,
+ * or the following URLs:
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * If you redistribute this file in source form, modified or unmodified, you
+ * may:
+ *   1) Leave this header intact and distribute it under the same terms,
+ *      accompanying it with the APACHE20 and GPL20 files, or
+ *   2) Delete the Apache 2.0 clause and accompany it with the GPL2 file, or
+ *   3) Delete the GPL v2 clause and accompany it with the APACHE20 file
+ * In all cases you must keep the copyright notice intact and include a copy
+ * of the CONTRIB file.
+ *
+ * Binary distributions must follow the binary distribution requirements of
+ * either License.
+ */
+
+#include "libfreenect.h"
+#include "libfreenect_sync.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+/* This is a simple demo. It connects to the kinect and plays with the motor,
+   the accelerometers, and the LED. It doesn't do anything with images. And,
+   unlike the other examples, no OpenGL is required! 
+   
+   So, this should serve as the reference example for working with the motor,
+   accelerometers, and LEDs.   */
+   
+void no_kinect_quit(void)
+{
+	printf("Error: Kinect not connected?\n");
+	exit(1);
+}
+   
+int main(int argc, char *argv[])
+{
+	srand(time(0));
+
+	while (1) {
+		// Pick a random tilt and a random LED state
+		int led  = rand() % 6;
+		int tilt = (rand() % 30)-15;
+		freenect_raw_tilt_state *state = 0;
+		double dx, dy, dz;
+
+		// Set the LEDs to one of the possible states
+		if (freenect_sync_set_led(led, 0)) no_kinect_quit();
+
+		// Set the tilt angle (in degrees)
+		if (freenect_sync_set_tilt_degs(tilt, 0)) no_kinect_quit();
+
+		// Get the raw accelerometer values and tilt data
+		if (freenect_sync_get_tilt_state(&state, 0)) no_kinect_quit();
+
+		// Get the processed accelerometer values (calibrated to gravity)
+		freenect_get_mks_accel(state, &dx, &dy, &dz);
+
+		printf("led[%d] tilt[%d] accel[%lf,%lf,%lf]\n", led, tilt, dx,dy,dz);
+
+		sleep(3);    
+	}
+}
+   
+

--- a/wrappers/c_sync/libfreenect_sync.c
+++ b/wrappers/c_sync/libfreenect_sync.c
@@ -330,6 +330,37 @@ static int sync_get(void **data, uint32_t *timestamp, buffer_ring_t *buf)
 	return 0;
 }
 
+
+/* 
+  Use this to make sure the runloop is locked and no one is in it. Then you can
+  call arbitrary functions from libfreenect.h in a safe way. If the kinect with
+  this index has not been initialized yet, then it will try to set it up. If 
+  this function is successful, then you can access kinects[index]. Don't forget
+  to unlock the runloop when you're done.
+  
+  Returns 0 if successful, nonzero if kinect[index] is unvailable
+ */ 
+static int runloop_enter(int index)
+{
+	if (index < 0 || index >= MAX_KINECTS) {
+		printf("Error: Invalid index [%d]\n", index);
+		return -1;
+	}
+	if (!thread_running || !kinects[index])
+		if (setup_kinect(index, FREENECT_DEPTH_11BIT, 1))
+			return -1;
+		
+	pending_runloop_tasks_inc();
+	pthread_mutex_lock(&runloop_lock);
+	return 0;
+}
+
+static void runloop_exit()
+{
+	pthread_mutex_unlock(&runloop_lock);
+	pending_runloop_tasks_dec();
+}
+
 int freenect_sync_get_video(void **video, uint32_t *timestamp, int index, freenect_video_format fmt)
 {
 	if (index < 0 || index >= MAX_KINECTS) {
@@ -356,31 +387,26 @@ int freenect_sync_get_depth(void **depth, uint32_t *timestamp, int index, freene
 	return 0;
 }
 
-int freenect_sync_get_accelerometers(int16_t *ax, int16_t *ay, int16_t *az, double *dx, double *dy, double *dz, int index) {
-	if (index < 0 || index >= MAX_KINECTS) {
-		printf("Error: Invalid index [%d]\n", index);
-		return -1;
-	}
-	if (!thread_running || !kinects[index])
-		return -1;
-	freenect_raw_tilt_state* state;
+int freenect_sync_get_tilt_state(freenect_raw_tilt_state **state, int index)
+{
+	if (runloop_enter(index)) return -1;
 	freenect_update_tilt_state(kinects[index]->dev);
-	state = freenect_get_tilt_state(kinects[index]->dev);
-	freenect_get_mks_accel(state, dx, dy, dz);
-    *ax = state->accelerometer_x;
-	*ay = state->accelerometer_y;
-	*az = state->accelerometer_z;
-    return 0;
+	*state = freenect_get_tilt_state(kinects[index]->dev);  
+	runloop_exit();
+	return 0;
 }
 
 int freenect_sync_set_tilt_degs(int angle, int index) {
-	if (index < 0 || index >= MAX_KINECTS) {
-		printf("Error: Invalid index [%d]\n", index);
-		return -1;
-	}
-	if (!thread_running || !kinects[index])
-		return -1;
+	if (runloop_enter(index)) return -1;
 	freenect_set_tilt_degs(kinects[index]->dev, angle);
+	runloop_exit();
+	return 0;
+}
+
+int freenect_sync_set_led(freenect_led_options led, int index) {
+	if (runloop_enter(index)) return -1;
+	freenect_set_led(kinects[index]->dev, led);
+	runloop_exit();
 	return 0;
 }
 

--- a/wrappers/c_sync/libfreenect_sync.h
+++ b/wrappers/c_sync/libfreenect_sync.h
@@ -67,31 +67,38 @@ int freenect_sync_get_depth(void **depth, uint32_t *timestamp, int index, freene
 */
 
 int freenect_sync_set_tilt_degs(int angle, int index);
-/*  Tilt function
+/*  Tilt function, starts the runloop if it isn't running
 
     Args:
         angle: Set the angle to tilt the device
-		index: Device index (0 is the first)
+		    index: Device index (0 is the first)
 
     Returns:
         Nonzero on error.
 */
 
-int freenect_sync_get_accelerometers(int16_t *ax, int16_t *ay, int16_t *az, double *dx, double *dy, double *dz, int index);
-/*  Accelerometers function
+int freenect_sync_get_tilt_state(freenect_raw_tilt_state **state, int index);
+/*  Tilt state function, starts the runloop if it isn't running
 
     Args:
-        ax: Populated with a pointer to the associated state->accelerometer_x
-        ay: Populated with a pointer to the associated state->accelerometer_y
-        az: Populated with a pointer to the associated state->accelerometer_y
-        dx: Populated with a pointer to the associated mks x
-        dy: Populated with a pointer to the associated mks y
-        dz: Populated with a pointer to the associated mks z
-		index: Device index (0 is the first)
+        state: Populated with an updated tilt state pointer
+		    index: Device index (0 is the first)
 
     Returns:
         Nonzero on error.
 */
+
+int freenect_sync_set_led(freenect_led_options led, int index);
+/*  Led function, starts the runloop if it isn't running
+
+    Args:
+        led: The LED state to set the device to
+		    index: Device index (0 is the first)
+
+    Returns:
+        Nonzero on error.
+*/
+
 
 void freenect_sync_stop(void);
 #ifdef __cplusplus


### PR DESCRIPTION
I added 'get_tilt_state', 'set_tilt_angle' and 'set_led' to the c_sync. This undoes the changes to c_sync in b815ccbf6346a2b8df32235ceb9dff84f03f9cf2, which were unsafe and caused thread corruption, but the same features are now provided. 

A new tilt_demo is added which uses the c_sync api to show off the accelerometers, the motor, and the LEDs. The advantage of this demo is that it has no OpenGL requirement, so it is the simplest way to check that your kinect is working. 
