### PR TITLE
Building cpp appart

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries (freenect ${LIBUSB_1_LIBRARIES})
 target_link_libraries (freenectstatic ${LIBUSB_1_LIBRARIES})
 
 # Install the header file
-install (FILES "../include/libfreenect.h" "../include/libfreenect.hpp"
+install (FILES "../include/libfreenect.h"
   DESTINATION ${PROJECT_INCLUDE_INSTALL_DIR})
 
 IF(UNIX AND NOT APPLE)

--- a/wrappers/cpp/CMakeLists.txt
+++ b/wrappers/cpp/CMakeLists.txt
@@ -36,3 +36,6 @@ endif()
 
 install (TARGETS cppview
   DESTINATION bin)
+install (FILES "libfreenect.hpp"
+  DESTINATION ${PROJECT_INCLUDE_INSTALL_DIR})
+


### PR DESCRIPTION
Moving the cpp wrapper to the wrappers directory broke the installation (complaining that the hpp header cannot be found). So moving the cmake installation directive for the hpp from src to wrappers/cpp
