### PR TITLE
Python demos, minor build change, and expose raw_tilt_state struct to python

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries (freenect ${LIBUSB_1_LIBRARIES})
 target_link_libraries (freenectstatic ${LIBUSB_1_LIBRARIES})
 
 # Install the header file
-install (FILES "../include/libfreenect.h" "../include/libfreenect.hpp"
+install (FILES "../include/libfreenect.h"
   DESTINATION ${PROJECT_INCLUDE_INSTALL_DIR})
 
 IF(UNIX AND NOT APPLE)

--- a/wrappers/python/README
+++ b/wrappers/python/README
@@ -12,8 +12,17 @@ Install
 - Global Install: sudo python setup.py install
 - Local Directory Install: python setup.py build_ext --inplace
 
+Why do the demos truncate the depth?
+The depth is 11 bits, if you want to display it as an 8 bit gray image you need to lose information somewhere.  The truncation allows you to differentiate between local depth differences but doesn't give you the absolute depth due to ambiguities; however, normalization gives you the absolute depth differences between pixels but you will lose resolution due to the difference between high and low depths.  We feel that this truncation produces the best results visually as a demo while being simple.  See glview for an example of using colors to extend the range.
+
+Do I need to call sync_stop when the program ends?
+No, it is not necessary.
+
 Do you need to run everything with root?
 No.  Use the udev drivers available in the project main directory.
+
+Why does sync_multi call sync_stop after each kinect?
+The goal is to test multiple kinects, but some machines don't have the USB bandwidth for it.  By default, this only lets one run at a time so that you can have many kinects on a hub or a slow laptop.  You can comment out the line if your machine can handle it.
 
 Differences From C Library
 Things that are intentially different to be more Pythonic
@@ -21,8 +30,7 @@ Things that are intentially different to be more Pythonic
 - Names: Everything is in the freenect module.  Since all freenect functions are of the form freenect_blah, we use freenect.blah to refer to them.  This is also true for the synchronous calls.
 
 Things not implemented (though could be added)
-- get/set user: Not implemented
-- Dev/Ctx/State: Opaque classes wrapping void *'s (you can't access struct elements)
+- Dev/Ctx: Opaque classes wrapping void *'s (you can't access struct elements)
 - Log functionality and callback
 
 Additional Features

--- a/wrappers/python/demo_cv_sync.py
+++ b/wrappers/python/demo_cv_sync.py
@@ -5,25 +5,11 @@ import numpy as np
 
 cv.NamedWindow('Depth')
 cv.NamedWindow('Video')
-size = (640, 480)
-
-# preallocate temporary images to avoid GC stalls and runtime memory allocs
-rgb=np.zeros((size[1],size[0],3),np.uint8)
-
+print('Press ESC in window to stop')
 while 1:
     depth, timestamp = freenect.sync_get_depth()
-    bgr, timestamp = freenect.sync_get_video()
-
-    # maximize dynamic range of the given 11 bits into the used 16 bits
-    depth<<=(16-11)
-    # Reordering bgr as rgb
-    # Using the slice directly doesn't work because the underlying buffer 
-    # is used and it does not change.
-    rgb[:] = bgr[:,:,::-1]
-
-    cv.ShowImage('Depth', depth)
-    cv.ShowImage('Video', rgb)
-    if cv.WaitKey(10) == 27 : break
-
-freenect.sync_stop()
-
+    rgb, timestamp = freenect.sync_get_video()
+    cv.ShowImage('Depth', depth.astype(np.uint8))
+    cv.ShowImage('Video', rgb[:, :, ::-1].astype(np.uint8))
+    if cv.WaitKey(10) == 27:
+        break

--- a/wrappers/python/demo_cv_sync_multi.py
+++ b/wrappers/python/demo_cv_sync_multi.py
@@ -3,33 +3,21 @@ import freenect
 import cv
 import numpy as np
 
-#cv.NamedWindow('Depth')
-#cv.NamedWindow('Video')
+cv.NamedWindow('Depth')
+cv.NamedWindow('Video')
 ind = 0
-size = (640, 480)
-
-# preallocate temporary images to avoid GC stalls and runtime memory allocs
-rgb=np.zeros((size[1],size[0],3),np.uint8)
-
+print('Press ESC to stop')
 while 1:
     print(ind)
     try:
         depth, timestamp = freenect.sync_get_depth(ind)
-        bgr, timestamp = freenect.sync_get_video(ind)
+        rgb, timestamp = freenect.sync_get_video(ind)
     except TypeError:
         ind = 0
         continue
-    # maximize dynamic range of the given 11 bits into the used 16 bits
-    depth<<=(16-11)
-    # Reordering bgr as rgb
-    # Using the slice directly doesn't work because the underlying buffer 
-    # is used and it does not change.
-    rgb[:] = bgr[:,:,::-1]
     ind += 1
-
-    cv.ShowImage('Depth %i'%ind, depth)
-    cv.ShowImage('Video %i'%ind, rgb)
-    if cv.WaitKey(10) == 27 : break
-
-freenect.sync_stop()
-
+    cv.ShowImage('Depth', depth.astype(np.uint8))
+    cv.ShowImage('Video', rgb[:, :, ::-1].astype(np.uint8))
+    if cv.WaitKey(10) == 27:
+        break
+    freenect.sync_stop()  # NOTE: May remove if you have good USB bandwidth

--- a/wrappers/python/demo_cv_thresh_sweep.py
+++ b/wrappers/python/demo_cv_thresh_sweep.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""Sweeps throught the depth image showing 100 range at a time"""
+import freenect
+import cv
+import numpy as np
+import time
+
+cv.NamedWindow('Depth')
+
+
+def disp_thresh(lower, upper):
+    depth, timestamp = freenect.sync_get_depth()
+    depth = 255 * np.logical_and(depth > lower, depth < upper)
+    cv.ShowImage('Depth', depth.astype(np.uint8))
+    cv.WaitKey(10)
+lower = 0
+upper = 100
+max_upper = 2048
+while upper < max_upper:
+    print('%d < depth < %d' % (lower, upper))
+    disp_thresh(lower, upper)
+    time.sleep(.1)
+    lower += 20
+    upper += 20

--- a/wrappers/python/demo_ipython.py
+++ b/wrappers/python/demo_ipython.py
@@ -1,24 +1,23 @@
 #!/usr/bin/env python
-from freenect import sync_get_depth, sync_get_video
-import cv  
+import freenect
+import cv
 import numpy as np
-  
+
+
 def doloop():
     global depth, rgb
     while True:
         # Get a fresh frame
-        (depth,_), (rgb,_) = sync_get_depth(), sync_get_video()
-	# Down sample 11 to 8 bits
-        depth >>=(11-8)
+        depth, _ = freenect.sync_get_depth()
+        rgb, _ = freenect.sync_get_video()
         # Build a two panel color image
-        d3 = np.dstack((depth,depth,depth)).astype(np.uint8)
-        da = np.hstack((d3,rgb))
-        
+        d3 = np.dstack((depth, depth, depth)).astype(np.uint8)
+        da = np.hstack((d3, rgb))
         # Simple Downsample
-        cv.ShowImage('both',np.array(da[::2,::2,::-1]))
-        if cv.WaitKey(5) == 27 : break
-    freenect.sync_stop()
-        
+        cv.ShowImage('both', np.array(da[::2, ::2, ::-1]))
+        if cv.WaitKey(10) == 27:
+            break
+print('Press ESC in window to stop')
 doloop()
 
 """
@@ -26,7 +25,5 @@ IPython usage:
  ipython
  [1]: run -i demo_freenect
  #<ctrl -c>  (to interrupt the loop)
- [2]: %timeit -n100 sync_get_depth(), sync_get_rgb() # profile the kinect capture
-
+ [2]: %timeit -n100 sync_get_depth(), sync_get_rgb() # profile kinect capture
 """
-

--- a/wrappers/python/demo_mp_async.py
+++ b/wrappers/python/demo_mp_async.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python
 import freenect
 import matplotlib.pyplot as mp
+import numpy as np
+import signal
 
 mp.ion()
 image_rgb = None
 image_depth = None
+keep_running = True
 
 
 def display_depth(dev, data, timestamp):
     global image_depth
+    data = data.astype(np.uint8)
+    mp.gray()
     mp.figure(1)
     if image_depth:
         image_depth.set_data(data)
@@ -26,5 +31,17 @@ def display_rgb(dev, data, timestamp):
         image_rgb = mp.imshow(data, interpolation='nearest', animated=True)
     mp.draw()
 
+
+def body(*args):
+    if not keep_running:
+        raise freenect.Kill
+
+
+def handler(signum, frame):
+    global keep_running
+    keep_running = False
+print('Press Ctrl-C in terminal to stop')
+signal.signal(signal.SIGINT, handler)
 freenect.runloop(depth=display_depth,
-                 video=display_rgb)
+                 video=display_rgb,
+                 body=body)

--- a/wrappers/python/demo_mp_sync.py
+++ b/wrappers/python/demo_mp_sync.py
@@ -1,16 +1,30 @@
 #!/usr/bin/env python
 import freenect
 import matplotlib.pyplot as mp
+import numpy as np
+import signal
 
+keep_running = True
 mp.ion()
 mp.figure(1)
-image_depth = mp.imshow(freenect.sync_get_depth()[0], interpolation='nearest', animated=True)
+mp.gray()
+image_depth = mp.imshow(freenect.sync_get_depth()[0].astype(np.uint8),
+                        interpolation='nearest', animated=True)
 mp.figure(2)
-image_rgb = mp.imshow(freenect.sync_get_video()[0], interpolation='nearest', animated=True)
+image_rgb = mp.imshow(freenect.sync_get_video()[0],
+                      interpolation='nearest', animated=True)
 
-while 1:
+
+def handler(signum, frame):
+    """Sets up the kill handler, catches SIGINT"""
+    global keep_running
+    keep_running = False
+print('Press Ctrl-C in terminal to stop')
+signal.signal(signal.SIGINT, handler)
+
+while keep_running:
     mp.figure(1)
-    image_depth.set_data(freenect.sync_get_depth()[0])
+    image_depth.set_data(freenect.sync_get_depth()[0].astype(np.uint8))
     mp.figure(2)
     image_rgb.set_data(freenect.sync_get_video()[0])
     mp.draw()

--- a/wrappers/python/demo_tilt.py
+++ b/wrappers/python/demo_tilt.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python
 import freenect
 import time
-import threading
 import random
-import time
+import signal
 
+keep_running = True
 last_time = 0
 
 
 def body(dev, ctx):
     global last_time
+    if not keep_running:
+        raise freenect.Kill
     if time.time() - last_time < 3:
         return
     last_time = time.time()
@@ -19,4 +21,11 @@ def body(dev, ctx):
     freenect.set_tilt_degs(dev, tilt)
     print('led[%d] tilt[%d] accel[%s]' % (led, tilt, freenect.get_accel(dev)))
 
+
+def handler(signum, frame):
+    """Sets up the kill handler, catches SIGINT"""
+    global keep_running
+    keep_running = False
+print('Press Ctrl-C in terminal to stop')
+signal.signal(signal.SIGINT, handler)
 freenect.runloop(body=body)


### PR DESCRIPTION
Cleaned up demos as per this post
http://groups.google.com/group/openkinect/browse_thread/thread/c72b3ade917152de
1. Every demo that runs forever has a way to kill (which is printed when you start the program)
2. The normalization is now consistent (uses truncation which amiller and I believe is a nicer visualization than normalization)
3. Updated readme to include these changes
4. Added a new demo that sweeps through the depth image displaying slices of depth at a time
5. Added more visibility to the raw_tilt_state struct in freenect.pyx
6. Removed "../include/libfreenect.hpp" from src/CMake\* as it doesn't exist there anymore
