### PR TITLE
Make the Python wrapper not require Cython on user's machines

### DIFF
--- a/src/cameras.c
+++ b/src/cameras.c
@@ -1083,7 +1083,7 @@ const freenect_frame_mode freenect_get_depth_mode(int mode_num)
 
 const freenect_frame_mode freenect_get_current_depth_mode(freenect_device *dev)
 {
-	return freenect_find_video_mode(dev->depth_resolution, dev->depth_format);
+	return freenect_find_depth_mode(dev->depth_resolution, dev->depth_format);
 }
 
 const freenect_frame_mode freenect_find_depth_mode(freenect_resolution res, freenect_depth_format fmt)


### PR DESCRIPTION
1. Updated setup.py to check if Cython is available and >= 0.13, if not fall back to the .c sources
2. Added the .c sources generated by Cython
