### PR TITLE
Add option to stream recorded RGB and depth video to ffmpeg for compression.

### DIFF
--- a/fakenect/record.c
+++ b/fakenect/record.c
@@ -32,11 +32,18 @@
 #include <stdlib.h>
 #include <sys/time.h>
 
-char *out_dir;
+char *out_dir=0;
 volatile sig_atomic_t running = 1;
 uint32_t last_timestamp = 0;
 FILE *index_fp = NULL;
 
+int use_ffmpeg = 0;
+char *ffmpeg_opts = 0;
+char *depth_name = 0;
+char *rgb_name = 0;
+
+FILE *depth_stream=0;
+FILE *rgb_stream=0;
 
 double get_time()
 {
@@ -73,6 +80,27 @@ FILE *open_dump(char type, double cur_time, uint32_t timestamp, int data_size, c
 	return fp;
 }
 
+FILE *open_ffmpeg(char *output_filename)
+{
+	char cmd[1024];
+
+	if (ffmpeg_opts==0)
+		ffmpeg_opts = "-aspect 4:3 -r 20 -vcodec msmpeg4 -b 30000k";
+
+	snprintf(cmd, 1024, "ffmpeg -pix_fmt rgb24 -s 640x480 -f rawvideo "
+			 "-i /dev/stdin %s %s", ffmpeg_opts, output_filename);
+
+	fprintf(stderr, "%s\n", cmd);
+
+	FILE* proc = popen(cmd, "w");
+	if (!proc) {
+		printf("Error: Cannot run ffmpeg\n");
+		exit(1);
+	}
+
+	return proc;
+}
+
 void dump(char type, uint32_t timestamp, void *data, int data_size)
 {
 	// timestamp can be at most 10 characters, we have a few extra
@@ -98,6 +126,24 @@ void dump(char type, uint32_t timestamp, void *data, int data_size)
 	}
 }
 
+void dump_ffmpeg_24(FILE *stream, uint32_t timestamp, void *data,
+					int data_size)
+{
+	fwrite(data, data_size, 1, stream);
+}
+
+void dump_ffmpeg_pad16(FILE *stream, uint32_t timestamp, void *data,
+					   int data_size)
+{
+	unsigned int z=0;
+	void *end = data + data_size;
+	while (data < end) {
+		z = *(unsigned short*)data;
+		fwrite(((char*)(&z)), 3, 1, stream);
+		data += 2;
+	}
+}
+
 void snapshot_accel(freenect_device *dev)
 {
 	if (!last_timestamp)
@@ -120,6 +166,25 @@ void rgb_cb(freenect_device *dev, void *rgb, uint32_t timestamp)
 	dump('r', timestamp, rgb, FREENECT_VIDEO_RGB_SIZE);
 }
 
+void depth_cb_ffmpeg(freenect_device *dev, void *depth, uint32_t timestamp)
+{
+	dump_ffmpeg_pad16(depth_stream, timestamp, depth,
+					  FREENECT_DEPTH_11BIT_SIZE);
+}
+
+
+void rgb_cb_ffmpeg(freenect_device *dev, void *rgb, uint32_t timestamp)
+{
+	dump_ffmpeg_24(rgb_stream, timestamp, rgb,
+				   FREENECT_VIDEO_RGB_SIZE);
+}
+
+void init_ffmpeg_streams()
+{
+	depth_stream = open_ffmpeg(depth_name);
+	rgb_stream = open_ffmpeg(rgb_name);
+}
+
 void init()
 {
 	freenect_context *ctx;
@@ -137,8 +202,14 @@ void init()
 	freenect_start_depth(dev);
 	freenect_set_video_format(dev, FREENECT_VIDEO_RGB);
 	freenect_start_video(dev);
-	freenect_set_depth_callback(dev, depth_cb);
-	freenect_set_video_callback(dev, rgb_cb);
+	if (use_ffmpeg) {
+		init_ffmpeg_streams();
+		freenect_set_depth_callback(dev, depth_cb_ffmpeg);
+		freenect_set_video_callback(dev, rgb_cb_ffmpeg);
+	} else {
+		freenect_set_depth_callback(dev, depth_cb);
+		freenect_set_video_callback(dev, rgb_cb);
+	}
 	while (running && freenect_process_events(ctx) >= 0)
 		snapshot_accel(dev);
 	freenect_stop_depth(dev);
@@ -154,29 +225,77 @@ void signal_cleanup(int num)
 	signal(SIGINT, signal_cleanup);
 }
 
+void usage()
+{
+	printf("Records the Kinect sensor data to a directory\nResult can be used as input to Fakenect\nUsage:\n");
+	printf("  record [-h] [-ffmpeg] [-ffmpeg-opts <options>] "
+		   "<target basename>\n");
+	exit(0);
+}
+
 int main(int argc, char **argv)
 {
-	if (argc != 2) {
-		printf("Records the Kinect sensor data to a directory\nResult can be used as input to Fakenect\nUsage: ./record <out_dir>\n");
-		return 1;
+	int c=1;
+	while (c < argc) {
+		if (strcmp(argv[c],"-ffmpeg")==0)
+			use_ffmpeg = 1;
+		else if (strcmp(argv[c],"-ffmpeg-opts")==0) {
+			if (++c < argc)
+				ffmpeg_opts = argv[c];
+		} else if (strcmp(argv[c],"-h")==0)
+			usage();
+		else
+			out_dir = argv[c];
+		c++;
 	}
-	out_dir = argv[1];
-	mkdir(out_dir, S_IRWXU | S_IRWXG | S_IRWXO);
+
+	if (!out_dir)
+		usage();
+
 	signal(SIGINT, signal_cleanup);
-	char *fn = malloc(strlen(out_dir) + 50);
-	sprintf(fn, "%s/INDEX.txt", out_dir);
-	index_fp = fopen(fn, "r");
-	if (index_fp) {
-		printf("Error: Index already exists, to avoid overwriting use a different directory.\n");
-		return 1;
+
+	if (use_ffmpeg) {
+		FILE *f;
+		depth_name = malloc(strlen(out_dir) + 50);
+		rgb_name = malloc(strlen(out_dir) + 50);
+		sprintf(depth_name, "%s-depth.avi", out_dir);
+		sprintf(rgb_name, "%s-rgb.avi", out_dir);
+		f = fopen(depth_name, "r");
+		if (f) {
+			printf("Error: %s already exists, to avoid overwriting "
+				   "use a different name.\n", depth_name);
+			fclose(f);
+			exit(1);
+		}
+		f = fopen(rgb_name, "r");
+		if (f) {
+			printf("Error: %s already exists, to avoid overwriting "
+				   "use a different name.\n", depth_name);
+			fclose(f);
+			exit(1);
+		}
+		init();
+		free(depth_name);
+		free(rgb_name);
+		if (depth_stream) fclose(depth_stream);
+		if (rgb_stream) fclose(rgb_stream);
+	} else {
+		mkdir(out_dir, S_IRWXU | S_IRWXG | S_IRWXO);
+		char *fn = malloc(strlen(out_dir) + 50);
+		sprintf(fn, "%s/INDEX.txt", out_dir);
+		index_fp = fopen(fn, "r");
+		if (index_fp) {
+			printf("Error: Index already exists, to avoid overwriting use a different directory.\n");
+			return 1;
+		}
+		index_fp = fopen(fn, "w");
+		if (!index_fp) {
+			printf("Error: Cannot open file [%s]\n", fn);
+			return 1;
+		}
+		free(fn);
+		init();
+		fclose(index_fp);
 	}
-	index_fp = fopen(fn, "w");
-	if (!index_fp) {
-		printf("Error: Cannot open file [%s]\n", fn);
-		return 1;
-	}
-	free(fn);
-	init();
-	fclose(index_fp);
 	return 0;
 }


### PR DESCRIPTION
I needed to make some longer recordings of Kinect data, but the current "record" utility writes uncompressed frames to disk which is unrealistic for this application.  A simple solution is to stream the raw data into ffmpeg and have it write it to disk as a compressed video stream.

This adds such an option to the "record" utility.  The main problem is that it does not handle frame rates very well, especially variable frame rates, and the compression can itself slow down acquisition from the kinect, so some buffering may be needed; however even this simple streaming seems better than nothing.  I could work on it more but I thought I'd submit it early since there may be experts in video and people more knowledgeable with ffmpeg that could help out if it lands in the main repo.  This patch doesn't interfere with the main functionality of the library, and running record without the additional options makes it behave exactly as before.
