### PR TITLE
Always build as a universal Binary 

### DIFF
--- a/platform/osx/homebrew/libusb-freenect.rb
+++ b/platform/osx/homebrew/libusb-freenect.rb
@@ -11,6 +11,7 @@ class LibusbFreenect <Formula
   end
 
   def install
+    ENV.universal_binary
     system "./autogen.sh"
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking", "LDFLAGS=-framework IOKit -framework CoreFoundation"
     system "make install"


### PR DESCRIPTION
This removes conflicts with OpenNI and other kinect libraries.
