### PR TITLE
Win32 can now lose the device without rendering the system unresponsive

### DIFF
--- a/platform/windows/libusb10emu/libusb-1.0/failguard.cpp
+++ b/platform/windows/libusb10emu/libusb-1.0/failguard.cpp
@@ -59,7 +59,7 @@ int ThreadFailGuardProc(void* params)
   int user_option =
   MessageBoxA(GetDesktopWindow(),
               "The libusb_handle_events() fail guard of libusbemu was reached!\n"
-              "This was caused by pressing the [ESC] key on the console window.\n"
+              "This was caused by pressing and holding the [CTRL] + [ALT] keys.\n"
               "If it was unintentional, click Cancel to resume normal execution;\n"
               "otherwise, click OK to effectively terminate the thread (note that\n"
               "the host program might run abnormally after such termination).",


### PR DESCRIPTION
initial support for disconnecting the Kinect device on-the-fly without hanging the system

Signed-off-by: Marcos Paulo Berteli Slomp mslomp@gmail.com
