### PR TITLE
USB Event Processing Timeout

### DIFF
--- a/src/usb_libusb10.c
+++ b/src/usb_libusb10.c
@@ -87,7 +87,10 @@ int fnusb_shutdown(fnusb_ctx *ctx)
 
 int fnusb_process_events(fnusb_ctx *ctx)
 {
-	return libusb_handle_events(ctx->ctx);
+	struct timeval t;
+	timerclear(&t);
+	t.tv_usec = 25600; // 0.0256 sec
+	return libusb_handle_events_timeout(ctx->ctx, &t);
 }
 
 int fnusb_open_subdevices(freenect_device *dev, int index)


### PR DESCRIPTION
Lower the timeout when invoking the USB Event processing from
60 seconds to 0.0256 seconds. This makes it possible to protect
access to freenect structures with a lock without having to wait
for a minute to acquire it between event processing.

Signed-off-by: Gerhard Roethlin gerhard@disneyresearch.com
