### PR TITLE
fakenect: add fakenect helper script

### DIFF
--- a/fakenect/CMakeLists.txt
+++ b/fakenect/CMakeLists.txt
@@ -16,3 +16,10 @@ add_executable(record record.c)
 target_link_libraries(record freenect m)
 install (TARGETS record
   DESTINATION bin)
+
+CONFIGURE_FILE("fakenect.sh.in"
+  "fakenect.sh"
+  IMMEDIATE @ONLY)
+install (PROGRAMS fakenect.sh
+  DESTINATION bin
+  RENAME fakenect)

--- a/fakenect/fakenect.sh.in
+++ b/fakenect/fakenect.sh.in
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# This file is part of the OpenKinect Project. http://www.openkinect.org
+#
+# Copyright (c) 2010 individual OpenKinect contributors. See the CONTRIB file
+# for details.
+#
+# This code is licensed to you under the terms of the Apache License, version
+# 2.0, or, at your option, the terms of the GNU General Public License,
+# version 2.0. See the APACHE20 and GPL20 files for the text of the licenses,
+# or the following URLs:
+# http://www.apache.org/licenses/LICENSE-2.0
+# http://www.gnu.org/licenses/gpl-2.0.txt
+#
+# If you redistribute this file in source form, modified or unmodified,
+# you may:
+# 1) Leave this header intact and distribute it under the same terms,
+# accompanying it with the APACHE20 and GPL20 files, or
+# 2) Delete the Apache 2.0 clause and accompany it with the GPL20 file, or
+# 3) Delete the GPL v2.0 clause and accompany it with the APACHE20 file
+# In all cases you must keep the copyright notice intact and include a copy
+# of the CONTRIB file.
+# Binary distributions must follow the binary distribution requirements of
+# either License.
+
+# fakenect wrapper script:
+# simplifies calling libfreenect applications under fakenect
+# by taking the fakenect database, app to run, and its args
+# then filling out the necessary environment variables and calling the app
+# usage: fakenect /path/to/fakenect/dump app --arg=value
+
+# catch bad args
+if [ $# -lt 2 ]
+then
+  echo "Usage: $0 <database> <application> <args>"
+  exit -1
+fi
+
+# set path to fakenect database
+export FAKENECT_PATH=$1
+
+# set link path (LD_LIBRARY_PATH for Linux, DYLIB_LIBRARY_PATH for OS X)
+if [ `uname` == "Darwin" ];
+then
+  export DYLD_LIBRARY_PATH="@CMAKE_INSTALL_PREFIX@/@PROJECT_LIBRARY_INSTALL_DIR@/fakenect/:${LD_LIBRARY_PATH}"
+else
+  export LD_LIBRARY_PATH="@CMAKE_INSTALL_PREFIX@/@PROJECT_LIBRARY_INSTALL_DIR@/fakenect/:${LD_LIBRARY_PATH}"
+fi
+
+# run desired app w/ args, now that environment is configured
+"${@:2}"


### PR DESCRIPTION
Hey, I've been using libfreenect a bit this summer and I'm going to run a local hackathon involving the library this fall semester at university. Since there are only so many kinects to go around, we are going to be using fakenect a bit for development and testing. I found calling it to be a bit cumbersome, so I added a little helper script to call fakenect that other users might find convenient.

---

Add a shell script to call libfreenect applications with fakenect.

Simplifies the use of fakenect by not requiring users to know or specify
environment variables and the like.

Usage:
fakenect <database> <application> <args>

Signed-off-by: Evan Shelhamer shelhamer@imaginarynumber.net
