### PR TITLE
C++ wrapper: ignore LIBUSB_ERROR_INTERRUPTED from freenect_process_events()

### DIFF
--- a/wrappers/cpp/libfreenect.hpp
+++ b/wrappers/cpp/libfreenect.hpp
@@ -28,8 +28,10 @@
 
 #include <libfreenect.h>
 #include <stdexcept>
+#include <sstream>
 #include <map>
 #include <pthread.h>
+#include <libusb-1.0/libusb.h>
 
 namespace Freenect {
 	class Noncopyable {
@@ -209,7 +211,20 @@ namespace Freenect {
 		// Do not call directly, thread runs here
 		void operator()() {
 			while(!m_stop) {
-				if(freenect_process_events(m_ctx) < 0) throw std::runtime_error("Cannot process freenect events");
+				int res = freenect_process_events(m_ctx);
+				if (res < 0)
+				{
+					// libusb signals an error has occurred
+					if (res == LIBUSB_ERROR_INTERRUPTED)
+					{
+						// This happens sometimes, it means that a system call in libusb was interrupted somehow (perhaps due to a signal)
+						// The simple solution seems to be just ignore it.
+						continue;
+					}
+					std::stringstream ss;
+					ss << "Cannot process freenect events (libusb error code: " << res << ")";
+					throw std::runtime_error(ss.str());
+				}
 			}
 		}
 		static void *pthread_callback(void *user_data) {


### PR DESCRIPTION
I kept getting errors about "Cannot process freenect events" when trying to
start cppview although glview worked perfectly. It turns out libusb kept
returning error "interrupted" when starting up, this patch ignores all
such errors from libusb.
I do not know libusb well enough to be able to tell whether this workaround
will cause any problems in special cases.
cppview seems to be working, but crashes when pressing ESC or closing the
window with the error "pure virtual method called". I'm still investigating
that error but I do not think it is related to this patch.

Signed-off-by: Joakim Gebart joakim.gebart@jge.se
