### PR TITLE
Hides private symbols

### DIFF
--- a/src/cameras.c
+++ b/src/cameras.c
@@ -38,7 +38,7 @@
 #define RESERVED_TO_FORMAT(reserved) ((reserved) & 0xff)
 
 #define video_mode_count 12
-freenect_frame_mode supported_video_modes[video_mode_count] = {
+static freenect_frame_mode supported_video_modes[video_mode_count] = {
 	// reserved, resolution, format, bytes, width, height, data_bits_per_pixel, padding_bits_per_pixel, framerate, is_valid
 	{MAKE_RESERVED(FREENECT_RESOLUTION_HIGH,   FREENECT_VIDEO_RGB), FREENECT_RESOLUTION_HIGH, {FREENECT_VIDEO_RGB}, 1280*1024*3, 1280, 1024, 24, 0, 10, 1 },
 	{MAKE_RESERVED(FREENECT_RESOLUTION_MEDIUM, FREENECT_VIDEO_RGB), FREENECT_RESOLUTION_MEDIUM, {FREENECT_VIDEO_RGB}, 640*480*3, 640,  480, 24, 0, 30, 1 },
@@ -61,7 +61,7 @@ freenect_frame_mode supported_video_modes[video_mode_count] = {
 };
 
 #define depth_mode_count 6
-freenect_frame_mode supported_depth_modes[depth_mode_count] = {
+static freenect_frame_mode supported_depth_modes[depth_mode_count] = {
 	// reserved, resolution, format, bytes, width, height, data_bits_per_pixel, padding_bits_per_pixel, framerate, is_valid
 	{MAKE_RESERVED(FREENECT_RESOLUTION_MEDIUM, FREENECT_DEPTH_11BIT), FREENECT_RESOLUTION_MEDIUM, {FREENECT_DEPTH_11BIT}, 640*480*2, 640, 480, 11, 5, 30, 1},
 	{MAKE_RESERVED(FREENECT_RESOLUTION_MEDIUM, FREENECT_DEPTH_10BIT), FREENECT_RESOLUTION_MEDIUM, {FREENECT_DEPTH_10BIT}, 640*480*2, 640, 480, 10, 6, 30, 1},
@@ -1318,7 +1318,7 @@ int freenect_set_video_buffer(freenect_device *dev, void *buf)
 	return stream_setbuf(dev->parent, &dev->video, buf);
 }
 
-int freenect_camera_init(freenect_device *dev)
+FN_INTERNAL int freenect_camera_init(freenect_device *dev)
 {
 	freenect_context *ctx = dev->parent;
 	int res;
@@ -1342,7 +1342,7 @@ int freenect_camera_init(freenect_device *dev)
 	return 0;
 }
 
-int freenect_camera_teardown(freenect_device *dev)
+FN_INTERNAL int freenect_camera_teardown(freenect_device *dev)
 {
 	freenect_context *ctx = dev->parent;
 	int res = 0;

--- a/src/core.c
+++ b/src/core.c
@@ -260,7 +260,7 @@ FREENECTAPI void freenect_set_log_callback(freenect_context *ctx, freenect_log_c
 	ctx->log_cb = cb;
 }
 
-void fn_log(freenect_context *ctx, freenect_loglevel level, const char *fmt, ...)
+FN_INTERNAL void fn_log(freenect_context *ctx, freenect_loglevel level, const char *fmt, ...)
 {
 	va_list ap;
 

--- a/src/freenect_internal.h
+++ b/src/freenect_internal.h
@@ -36,6 +36,13 @@
 #include "libfreenect-audio.h"
 #endif
 
+#ifdef __ELF__
+#define FN_INTERNAL	__attribute__ ((visibility ("hidden")))
+#else
+#define FN_INTERNAL
+#endif
+
+
 typedef void (*fnusb_iso_cb)(freenect_device *dev, uint8_t *buf, int len);
 
 #include "usb_libusb10.h"

--- a/src/loader.c
+++ b/src/loader.c
@@ -119,7 +119,7 @@ static int check_version_string(fnusb_dev* dev) {
 	return res;
 }
 
-int upload_firmware(fnusb_dev* dev) {
+FN_INTERNAL int upload_firmware(fnusb_dev* dev) {
 	freenect_context* ctx = dev->parent->parent;
 	bootloader_command bootcmd;
 	memset(&bootcmd, 0, sizeof(bootcmd));
@@ -247,7 +247,7 @@ int upload_firmware(fnusb_dev* dev) {
 	return 0;
 }
 
-int upload_cemd_data(fnusb_dev* dev) {
+FN_INTERNAL int upload_cemd_data(fnusb_dev* dev) {
 	// Now we upload the CEMD data.
 	freenect_context* ctx = dev->parent->parent;
 	cemdloader_command cemdcmd;

--- a/src/registration.c
+++ b/src/registration.c
@@ -74,7 +74,7 @@ static void freenect_init_depth_to_rgb(int32_t* depth_to_rgb, freenect_zero_plan
 }
 
 // unrolled inner loop of the 11-bit unpacker
-inline void unpack_8_pixels(uint8_t *raw, uint16_t *frame)
+static inline void unpack_8_pixels(uint8_t *raw, uint16_t *frame)
 {
 	uint16_t baseMask = 0x7FF;
 
@@ -101,7 +101,7 @@ inline void unpack_8_pixels(uint8_t *raw, uint16_t *frame)
 }
 
 // apply registration data to a single packed frame
-int freenect_apply_registration(freenect_device* dev, uint8_t* input_packed, uint16_t* output_mm)
+FN_INTERNAL int freenect_apply_registration(freenect_device* dev, uint8_t* input_packed, uint16_t* output_mm)
 {
 	freenect_registration* reg = &(dev->registration);
 	// set output buffer to zero using pointer-sized memory access (~ 30-40% faster than memset)
@@ -169,7 +169,7 @@ int freenect_apply_registration(freenect_device* dev, uint8_t* input_packed, uin
 }
 
 // Same as freenect_apply_registration, but don't bother aligning to the RGB image
-int freenect_apply_depth_to_mm(freenect_device* dev, uint8_t* input_packed, uint16_t* output_mm)
+FN_INTERNAL int freenect_apply_depth_to_mm(freenect_device* dev, uint8_t* input_packed, uint16_t* output_mm)
 {
 	freenect_registration* reg = &(dev->registration);
 	uint16_t unpack[8];
@@ -289,9 +289,9 @@ static void freenect_init_registration_table(int32_t (*registration_table)[2], f
 }
 
 // These are just constants.
-double parameter_coefficient = 4;
-double shift_scale = 10;
-double pixel_size_factor = 1;
+static double parameter_coefficient = 4;
+static double shift_scale = 10;
+static double pixel_size_factor = 1;
 
 /// convert raw shift value to metric depth (in mm)
 static uint16_t freenect_raw_to_mm(uint16_t raw, freenect_registration* reg)
@@ -332,7 +332,7 @@ void freenect_camera_to_world(freenect_device* dev, int cx, int cy, int wz, doub
 /// Allocate and fill registration tables
 /// This function should be called every time a new video (not depth!) mode is
 /// activated.
-int freenect_init_registration(freenect_device* dev)
+FN_INTERNAL int freenect_init_registration(freenect_device* dev)
 {
 	freenect_registration* reg = &(dev->registration);
 

--- a/src/usb_libusb10.c
+++ b/src/usb_libusb10.c
@@ -33,7 +33,7 @@
 #include "freenect_internal.h"
 #include "loader.h"
 
-int fnusb_num_devices(fnusb_ctx *ctx)
+FN_INTERNAL int fnusb_num_devices(fnusb_ctx *ctx)
 {
 	libusb_device **devs; 
 	//pointer to pointer of device, used to retrieve a list of devices	
@@ -56,7 +56,7 @@ int fnusb_num_devices(fnusb_ctx *ctx)
 	return nr;
 }
 
-int fnusb_list_device_attributes(fnusb_ctx *ctx, struct freenect_device_attributes** attribute_list)
+FN_INTERNAL int fnusb_list_device_attributes(fnusb_ctx *ctx, struct freenect_device_attributes** attribute_list)
 {
 	*attribute_list = NULL; // initialize some return value in case the user is careless.
 	libusb_device **devs;
@@ -116,7 +116,7 @@ int fnusb_list_device_attributes(fnusb_ctx *ctx, struct freenect_device_attribut
 	return num_cams;
 }
 
-int fnusb_init(fnusb_ctx *ctx, freenect_usb_context *usb_ctx)
+FN_INTERNAL int fnusb_init(fnusb_ctx *ctx, freenect_usb_context *usb_ctx)
 {
 	int res;
 	if (!usb_ctx) {
@@ -137,7 +137,7 @@ int fnusb_init(fnusb_ctx *ctx, freenect_usb_context *usb_ctx)
 	}
 }
 
-int fnusb_shutdown(fnusb_ctx *ctx)
+FN_INTERNAL int fnusb_shutdown(fnusb_ctx *ctx)
 {
 	//int res;
 	if (ctx->should_free_ctx) {
@@ -147,17 +147,17 @@ int fnusb_shutdown(fnusb_ctx *ctx)
 	return 0;
 }
 
-int fnusb_process_events(fnusb_ctx *ctx)
+FN_INTERNAL int fnusb_process_events(fnusb_ctx *ctx)
 {
 	return libusb_handle_events(ctx->ctx);
 }
 
-int fnusb_process_events_timeout(fnusb_ctx *ctx, struct timeval* timeout)
+FN_INTERNAL int fnusb_process_events_timeout(fnusb_ctx *ctx, struct timeval* timeout)
 {
 	return libusb_handle_events_timeout(ctx->ctx, timeout);
 }
 
-int fnusb_open_subdevices(freenect_device *dev, int index)
+FN_INTERNAL int fnusb_open_subdevices(freenect_device *dev, int index)
 {
 	freenect_context *ctx = dev->parent;
 
@@ -392,7 +392,7 @@ int fnusb_open_subdevices(freenect_device *dev, int index)
 	}
 }
 
-int fnusb_close_subdevices(freenect_device *dev)
+FN_INTERNAL int fnusb_close_subdevices(freenect_device *dev)
 {
 	if (dev->usb_cam.dev) {
 		libusb_release_interface(dev->usb_cam.dev, 0);
@@ -499,7 +499,7 @@ static void iso_callback(struct libusb_transfer *xfer)
 	}
 }
 
-int fnusb_start_iso(fnusb_dev *dev, fnusb_isoc_stream *strm, fnusb_iso_cb cb, int ep, int xfers, int pkts, int len)
+FN_INTERNAL int fnusb_start_iso(fnusb_dev *dev, fnusb_isoc_stream *strm, fnusb_iso_cb cb, int ep, int xfers, int pkts, int len)
 {
 	freenect_context *ctx = dev->parent->parent;
 	int ret, i;
@@ -537,7 +537,7 @@ int fnusb_start_iso(fnusb_dev *dev, fnusb_isoc_stream *strm, fnusb_iso_cb cb, in
 
 }
 
-int fnusb_stop_iso(fnusb_dev *dev, fnusb_isoc_stream *strm)
+FN_INTERNAL int fnusb_stop_iso(fnusb_dev *dev, fnusb_isoc_stream *strm)
 {
 	freenect_context *ctx = dev->parent->parent;
 	int i;
@@ -568,17 +568,17 @@ int fnusb_stop_iso(fnusb_dev *dev, fnusb_isoc_stream *strm)
 	return 0;
 }
 
-int fnusb_control(fnusb_dev *dev, uint8_t bmRequestType, uint8_t bRequest, uint16_t wValue, uint16_t wIndex, uint8_t *data, uint16_t wLength)
+FN_INTERNAL int fnusb_control(fnusb_dev *dev, uint8_t bmRequestType, uint8_t bRequest, uint16_t wValue, uint16_t wIndex, uint8_t *data, uint16_t wLength)
 {
 	return libusb_control_transfer(dev->dev, bmRequestType, bRequest, wValue, wIndex, data, wLength, 0);
 }
 
 #ifdef BUILD_AUDIO
-int fnusb_bulk(fnusb_dev *dev, uint8_t endpoint, uint8_t *data, int len, int *transferred) {
+FN_INTERNAL int fnusb_bulk(fnusb_dev *dev, uint8_t endpoint, uint8_t *data, int len, int *transferred) {
 	return libusb_bulk_transfer(dev->dev, endpoint, data, len, transferred, 0);
 }
 
-int fnusb_num_interfaces(fnusb_dev *dev) {
+FN_INTERNAL int fnusb_num_interfaces(fnusb_dev *dev) {
 	int retval = 0;
 	int res;
 	libusb_device* d = libusb_get_device(dev->dev);


### PR DESCRIPTION
Mark all non static internal functions with visibility hidden on
ELF platform. Declare some internal symbols that were meant to have
static linkage as such. On win32 the hidden visibility is no op since
it is the default behavior. 

Signed-off-by: Nicolas Bourdaud nicolas.bourdaud@gmail.com
