### PR TITLE
Added error reporting for failed subdevice initialization.

### DIFF
--- a/src/usb_libusb10.c
+++ b/src/usb_libusb10.c
@@ -377,15 +377,23 @@ int fnusb_open_subdevices(freenect_device *dev, int index)
 		if (dev->usb_cam.dev) {
 			libusb_release_interface(dev->usb_cam.dev, 0);
 			libusb_close(dev->usb_cam.dev);
+		} else {
+			FN_ERROR("Failed to open camera subdevice or it is not disabled.");
 		}
+
 		if (dev->usb_motor.dev) {
 			libusb_release_interface(dev->usb_motor.dev, 0);
 			libusb_close(dev->usb_motor.dev);
+		} else {
+			FN_ERROR("Failed to open motor subddevice or it is not disabled.");
 		}
+
 #ifdef BUILD_AUDIO
 		if (dev->usb_audio.dev) {
 			libusb_release_interface(dev->usb_audio.dev, 0);
 			libusb_close(dev->usb_audio.dev);
+		} else {
+			FN_ERROR("Failed to open audio subdevice or it is not disabled.");
 		}
 #endif
 		return -1;


### PR DESCRIPTION
The error was encountered on Win32 when _only_ the Camera subdevice
had a proper driver installed. This caused a silent failure.

Signed-off-by: JD Cole jd@jdc.me
