### PR TITLE
Add access to the underlying C freenect_device in c++ wrapper

### DIFF
--- a/wrappers/cpp/libfreenect.hpp
+++ b/wrappers/cpp/libfreenect.hpp
@@ -132,6 +132,9 @@ namespace Freenect {
 		freenect_resolution getDepthResolution() {
 			return m_depth_resolution;
 		}
+		const freenect_device *getDevice() {
+			return m_dev;
+		}
 		// Do not call directly even in child
 		virtual void VideoCallback(void *video, uint32_t timestamp) = 0;
 		// Do not call directly even in child


### PR DESCRIPTION
I found it necessary to have access to the underlying freenect_device struct in the c++ wrapper.  I added a small function to access the device.
