### PR TITLE
Changed the GLUT Includes in the CMakeLists.txt files to properly include GLUT

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -56,7 +56,7 @@ else()
   find_package(OpenGL REQUIRED)
   find_package(GLUT REQUIRED)
 
-  include_directories(${OPENGL_INCLUDE_DIRS} ${GLUT_INCLUDE_DIRS} ${USB_INCLUDE_DIRS})
+  include_directories(${OPENGL_INCLUDE_DIRS} ${GLUT_INCLUDE_PATH} ${USB_INCLUDE_DIRS})
 
   target_link_libraries(glview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
   target_link_libraries(regview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})

--- a/wrappers/cpp/CMakeLists.txt
+++ b/wrappers/cpp/CMakeLists.txt
@@ -25,7 +25,7 @@ else()
   find_package(OpenGL REQUIRED)
   find_package(GLUT REQUIRED)
 
-  include_directories(${OPENGL_INCLUDE_DIRS} ${GLUT_INCLUDE_DIRS} ${USB_INCLUDE_DIRS})
+  include_directories(${OPENGL_INCLUDE_DIRS} ${GLUT_INCLUDE_PATH} ${USB_INCLUDE_DIRS})
 
   target_link_libraries(cppview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
 endif()


### PR DESCRIPTION
Originally, GLUT_INCLUDE_DIRS was used in the CMakeLists.txt for GLUT.

The FindGLUT.cmake included with CMake never sets that variable. This fix changes that to the variable that is actually set: GLUT_INCLUDE_PATH.
