### PR TITLE
C++ Wrapper GLUT Include Misspelling

### DIFF
--- a/wrappers/cpp/CMakeLists.txt
+++ b/wrappers/cpp/CMakeLists.txt
@@ -25,7 +25,7 @@ else()
   find_package(OpenGL REQUIRED)
   find_package(GLUT REQUIRED)
 
-  include_directories(${OPENGL_INCLUDE_DIRS} ${GLUT_INCLUDE_DIRS} ${USB_INCLUDE_DIRS})
+  include_directories(${OPENGL_INCLUDE_DIRS} ${GLUT_INCLUDE_DIR} ${USB_INCLUDE_DIRS})
 
   target_link_libraries(cppview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
 endif()


### PR DESCRIPTION
While the change has already been made for the examples folder CMakeLists.txt, the one in the C++ wrapper was not included in the fix.
