### PR TITLE
Fixed brew install issues on OSX 10.8.3 (XCode 4.6.1)

### DIFF
--- a/platform/osx/homebrew/libusb-freenect.rb
+++ b/platform/osx/homebrew/libusb-freenect.rb
@@ -15,6 +15,9 @@ class LibusbFreenect <Formula
   end
 
   def install
+    # Compatibility with Automake 1.13 and newer.
+    inreplace 'configure.ac', 'AM_CONFIG_HEADER', 'AC_CONFIG_HEADERS'
+    
     ENV.universal_binary
     system "./autogen.sh"
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking", "LDFLAGS=-framework IOKit -framework CoreFoundation"


### PR DESCRIPTION
I just attempted to brew install libfreenect using [these instructions](http://openkinect.org/wiki/Getting_Started#Homebrew) and hit [this error](https://github.com/mxcl/homebrew/issues/17266) on my late-2012 model MacBook Air running OSX 10.8.3 (XCode 4.6.1). After installing the latest CLT for this XCode version, brew doctor was solid and I ran into the above error. I attempted the suggested fix to libusb-freenect on that page, all worked well, and so here it is as a patch.

Note: I haven't tested this fix anywhere else, nor have I checked on any other OSX installs to ensure it doesn't break anything on previous version of Mac.
