### PR TITLE
Kinect for Windows and Kinect for Xbox 360 Model 1473 support

### DIFF
--- a/include/libfreenect.h
+++ b/include/libfreenect.h
@@ -303,6 +303,15 @@ FREENECTAPI int freenect_supported_subdevices(void);
 FREENECTAPI void freenect_select_subdevices(freenect_context *ctx, freenect_device_flags subdevs);
 
 /**
+ * Returns the devices that are enabled after calls to freenect_open_device()
+ * On newer kinects the motor and audio are automatically disabled for now
+ *
+ * @param ctx Context to set future subdevice selection for
+ * @return Flags representing the subdevices that were actually opened (see freenect_device_flags)
+ */
+FREENECTAPI freenect_device_flags freenect_enabled_subdevices(freenect_context *ctx);
+
+/**
  * Opens a kinect device via a context. Index specifies the index of
  * the device on the current state of the bus. Bus resets may cause
  * indexes to shift.

--- a/platform/windows/libusb10emu/libusb-1.0/libusb.h
+++ b/platform/windows/libusb10emu/libusb-1.0/libusb.h
@@ -77,6 +77,7 @@ int libusb_get_string_descriptor(libusb_device_handle *dev_handle, uint8_t desc_
 int libusb_get_string_descriptor_ascii(libusb_device_handle *dev_handle, uint8_t desc_index, unsigned char *data, int length);
 
 int libusb_set_configuration(libusb_device_handle *dev, int configuration);
+int libusb_set_interface_alt_setting(libusb_device_handle *dev,int interface_number,int alternate_setting);	
 int libusb_claim_interface(libusb_device_handle* dev, int interface_number);
 int libusb_release_interface(libusb_device_handle* dev, int interface_number);
 

--- a/platform/windows/libusb10emu/libusb-1.0/libusbemu.cpp
+++ b/platform/windows/libusb10emu/libusb-1.0/libusbemu.cpp
@@ -302,6 +302,17 @@ int libusb_set_configuration(libusb_device_handle *dev, int configuration)
   return 0;
 }
 
+int libusb_set_interface_alt_setting(libusb_device_handle *dev, int interface_number,int alternate_setting){
+  RAIIMutex lock (dev->dev->ctx->mutex);
+  if (0 != usb_set_altinterface(dev->handle, alternate_setting))
+  {
+    LIBUSBEMU_ERROR_LIBUSBWIN32();
+    return(LIBUSB_ERROR_OTHER);
+  }
+	
+  return(0);	
+}	
+
 int libusb_claim_interface(libusb_device_handle* dev, int interface_number)
 {
   RAIIMutex lock (dev->dev->ctx->mutex);

--- a/src/cameras.c
+++ b/src/cameras.c
@@ -904,9 +904,9 @@ static int freenect_fetch_zero_plane_info(freenect_device *dev)
 	uint16_t cmd[5] = {0}; // Offset is the only field in this command, and it's 0
 
 	int res;
-	res = send_cmd(dev, 0x04, cmd, 10, reply, 322); //OPCODE_GET_FIXED_PARAMS = 4,
-	if (res != 322) {
-		FN_ERROR("freenect_fetch_zero_plane_info: send_cmd read %d bytes (expected 322)\n", res);
+	res = send_cmd(dev, 0x04, cmd, 10, reply, ctx->zero_plane_res); //OPCODE_GET_FIXED_PARAMS = 4,
+	if (res != ctx->zero_plane_res) {
+		FN_ERROR("freenect_fetch_zero_plane_info: send_cmd read %d bytes (expected %d)\n", res,ctx->zero_plane_res);
 		return -1;
 	}
 

--- a/src/core.c
+++ b/src/core.c
@@ -148,6 +148,10 @@ FREENECTAPI void freenect_select_subdevices(freenect_context *ctx, freenect_devi
 			));
 }
 
+FREENECTAPI freenect_device_flags freenect_enabled_subdevices(freenect_context *ctx) {
+	return ctx->enabled_subdevices;
+}
+
 FREENECTAPI int freenect_open_device(freenect_context *ctx, freenect_device **dev, int index)
 {
 	int res;

--- a/src/freenect_internal.h
+++ b/src/freenect_internal.h
@@ -52,6 +52,7 @@ struct _freenect_context {
 	fnusb_ctx usb;
 	freenect_device_flags enabled_subdevices;
 	freenect_device *first;
+	int zero_plane_res;
 };
 
 #define LL_FATAL FREENECT_LOG_FATAL
@@ -131,6 +132,8 @@ static inline int32_t fn_le32s(int32_t s)
 #define PID_NUI_AUDIO 0x02ad
 #define PID_NUI_CAMERA 0x02ae
 #define PID_NUI_MOTOR 0x02b0
+#define PID_K4W_CAMERA 0x02bf
+#define PID_K4W_AUDIO 0x02be
 
 typedef struct {
 	int running;

--- a/src/tilt.c
+++ b/src/tilt.c
@@ -47,6 +47,8 @@ freenect_raw_tilt_state* freenect_get_tilt_state(freenect_device *dev)
 int freenect_update_tilt_state(freenect_device *dev)
 {
 	freenect_context *ctx = dev->parent;
+	if(!(ctx->enabled_subdevices & FREENECT_DEVICE_MOTOR))
+		return 0;
 	uint8_t buf[10];
 	uint16_t ux, uy, uz;
 	int ret = fnusb_control(&dev->usb_motor, 0xC0, 0x32, 0x0, 0x0, buf, 10);
@@ -70,6 +72,9 @@ int freenect_update_tilt_state(freenect_device *dev)
 
 int freenect_set_tilt_degs(freenect_device *dev, double angle)
 {
+	freenect_context *ctx = dev->parent;
+	if(!(ctx->enabled_subdevices & FREENECT_DEVICE_MOTOR))
+		return 0;
 	int ret;
 	uint8_t empty[0x1];
 
@@ -82,6 +87,9 @@ int freenect_set_tilt_degs(freenect_device *dev, double angle)
 
 int freenect_set_led(freenect_device *dev, freenect_led_options option)
 {
+	freenect_context *ctx = dev->parent;
+	if(!(ctx->enabled_subdevices & FREENECT_DEVICE_MOTOR))
+		return 0;
 	int ret;
 	uint8_t empty[0x1];
 	ret = fnusb_control(&dev->usb_motor, 0x40, 0x06, (uint16_t)option, 0x0, empty, 0x0);


### PR DESCRIPTION
This patch does auto detection of all three models and disables motor subdevice for the 2 newer ones. It also
adds a function to test for the presence of the motor and audio devices on newer models.
