### PR TITLE
Stream mirroring

### DIFF
--- a/include/libfreenect.h
+++ b/include/libfreenect.h
@@ -106,6 +106,11 @@ typedef enum {
 	FREENECT_DEPTH_DUMMY        = 2147483647, /**< Dummy value to force enum to be 32 bits wide */
 } freenect_depth_format;
 
+typedef enum {
+	FREENECT_MIRRORING_OFF = 0,
+	FREENECT_MIRRORING_ON = 1,
+} freenect_mirroring_flag;
+
 /// Structure to give information about the width, height, bitrate,
 /// framerate, and buffer size of a frame in a particular mode, as
 /// well as the total number of bytes needed to hold a single frame.
@@ -399,6 +404,23 @@ FREENECTAPI int freenect_set_depth_buffer(freenect_device *dev, void *buf);
  * @return 0 on success, < 0 on error
  */
 FREENECTAPI int freenect_set_video_buffer(freenect_device *dev, void *buf);
+
+/**
+ * Toggle mirroring for the depth stream.
+ * 
+ * @param dev Device for which to set mirroring
+ * @param flag Flag to toggle mirroring
+ */
+FREENECTAPI void freenect_set_depth_mirroring(freenect_device *dev, freenect_mirroring_flag flag);
+
+/**
+ * Toggle mirroring for the video stream.
+ * Note that the IR stream cannot be mirrored since that would corrupt depth.
+ * 
+ * @param dev Device for which to set mirroring
+ * @param flag Flag to toggle mirroring
+ */
+FREENECTAPI void freenect_set_video_mirroring(freenect_device *dev, freenect_mirroring_flag flag);
 
 /**
  * Start the depth information stream for a device.

--- a/src/cameras.c
+++ b/src/cameras.c
@@ -1324,6 +1324,7 @@ int freenect_set_depth_mode(freenect_device* dev, const freenect_frame_mode mode
 	dev->depth_resolution = res;
 	return 0;
 }
+
 int freenect_set_depth_buffer(freenect_device *dev, void *buf)
 {
 	return stream_setbuf(dev->parent, &dev->depth, buf);
@@ -1332,6 +1333,16 @@ int freenect_set_depth_buffer(freenect_device *dev, void *buf)
 int freenect_set_video_buffer(freenect_device *dev, void *buf)
 {
 	return stream_setbuf(dev->parent, &dev->video, buf);
+}
+
+void freenect_set_depth_mirroring(freenect_device *dev, freenect_mirroring_flag flag)
+{
+	write_register(dev, 0x0017, flag);
+}
+
+void freenect_set_video_mirroring(freenect_device *dev, freenect_mirroring_flag flag)
+{
+	write_register(dev, 0x0047, flag);
 }
 
 FN_INTERNAL int freenect_camera_init(freenect_device *dev)


### PR DESCRIPTION
This adds support for mirroring depth and video streams.  There are two caveats:
- The IR stream cannot be mirrored in hardware since doing so corrupts the stream.
- Video stream is of lower quality because the Bayer decoder assumes a GB interleave but a mirrored stream has a BG interleave.

Signed-off-by: Benn Snyder benn.snyder@gmail.com
