### PR TITLE
freenect_flag should be a real flags enum (raw registers should be coded differently)

### DIFF
--- a/include/libfreenect.h
+++ b/include/libfreenect.h
@@ -113,8 +113,8 @@ typedef enum {
 	FREENECT_AUTO_WHITE_BALANCE = 1 << 1,
 	FREENECT_RAW_COLOR          = 1 << 4,
 	// registers to be written with 0 or 1
-	FREENECT_MIRROR_DEPTH       = 0x0017,
-	FREENECT_MIRROR_VIDEO       = 0x0047,
+	FREENECT_MIRROR_DEPTH       = 1 << 16,
+	FREENECT_MIRROR_VIDEO       = 1 << 17,
 } freenect_flag;
 
 /// Possible values for setting each `freenect_flag`

--- a/src/flags.c
+++ b/src/flags.c
@@ -32,12 +32,26 @@
 // freenect_set_flag is the only function exposed in libfreenect.h
 // The rest are available internally via #include flags.h
 
+static int register_for_flag(int flag) {
+    switch(flag) {
+    case FREENECT_MIRROR_DEPTH:
+        return 0x17;
+    case FREENECT_MIRROR_VIDEO:
+        return 0x47;
+    default:
+        return -1;
+    }
+}
 
 int freenect_set_flag(freenect_device *dev, freenect_flag flag, freenect_flag_value value)
 {
-	if (flag == FREENECT_MIRROR_DEPTH || flag == FREENECT_MIRROR_VIDEO)
-		return write_register(dev, flag, value);
-	
+    if (flag >= (1<<16)) {
+        int reg = register_for_flag(flag);
+        if(reg < 0)
+            return -1;
+        return write_register(dev, reg, value);
+    }
+
 	uint16_t reg = read_cmos_register(dev, 0x0106);
 	if (reg < 0)
 		return reg;


### PR DESCRIPTION
This changes `freenect_flag` to be a real flags enum, i.e. one where you can set individual bits in the enum (could be used to set settings in bulk in the future, for example, or to quickly query the set of active flags). It is a fix for [issue #341](https://github.com/OpenKinect/libfreenect/issues/341).
