### PR TITLE
fix typo in changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-libfreenect(1:0.2.0-0ubuntu1~raring) raring; urgency=low
+libfreenect (1:0.2.0-0ubuntu1~raring) raring; urgency=low
 
   * Kinect for Windows and Kinect for Xbox 360 Model 1473 support #325
   * Camera Flags - Auto Exposure, Auto White Balance, Raw Color, & Mirror #332


### PR DESCRIPTION
fix a typo which breaks the dpkg parser
