### PR TITLE
Fix include of libusb.h in wrappers/cpp/libfreenect.hpp

### DIFF
--- a/wrappers/cpp/libfreenect.hpp
+++ b/wrappers/cpp/libfreenect.hpp
@@ -31,7 +31,7 @@
 #include <sstream>
 #include <map>
 #include <pthread.h>
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 
 namespace Freenect {
 	class Noncopyable {


### PR DESCRIPTION
Otherwise fails to build on systems with libusb.h provided outside of versioned
directory, e.g. on kFreeBSD.  This "bug" was introduced after initial
changes of similar kind in e.g. 713c715 and 8219750

Signed-off-by: Yaroslav Halchenko debian@onerussian.com
