### PR TITLE
Making C++ wrapper compatible with C++11.

### DIFF
--- a/wrappers/cpp/libfreenect.hpp
+++ b/wrappers/cpp/libfreenect.hpp
@@ -199,7 +199,7 @@ namespace Freenect {
 			DeviceMap::iterator it = m_devices.find(_index);
 			if (it != m_devices.end()) delete it->second;
 			ConcreteDevice * device = new ConcreteDevice(m_ctx, _index);
-			m_devices.insert(std::make_pair<int, FreenectDevice*>(_index, device));
+			m_devices.insert(std::pair<int, FreenectDevice*>(_index, device));
 			return *device;
 		}
 		void deleteDevice(int _index) {


### PR DESCRIPTION
Compiling with a simple sample app with C++11 fails. This is due to the changes
to the std::make_pair function. More details are available here:

http://www.cplusplus.com/reference/utility/make_pair/
http://stackoverflow.com/questions/9641960/c11-make-pair-with-specified-template-parameters-doesnt-compile

The applied change means that the code compiles correctly for both C++03 and
C++11. make_pair was never necessary, since the types are explicitly specified
anyway.
