### PR TITLE
Prevent attempt to write write_cmos_register() if read_cmos_register() failed

### DIFF
--- a/src/flags.c
+++ b/src/flags.c
@@ -53,7 +53,7 @@ int freenect_set_flag(freenect_device *dev, freenect_flag flag, freenect_flag_va
     }
 
 	uint16_t reg = read_cmos_register(dev, 0x0106);
-	if (reg < 0)
+	if (reg == -1)
 		return reg;
 	if (value == FREENECT_ON)
 		reg |= flag;
@@ -188,7 +188,7 @@ FN_INTERNAL uint16_t read_cmos_register(freenect_device *dev, uint16_t reg)
 	int res = send_cmd(dev, 0x95, cmdbuf, 6, replybuf, 6);
 	if (res < 0) {
 		FN_ERROR("read_cmos_register: send_cmd() returned %d\n", res);
-		return res;
+		return -1;
 	}
 	return replybuf[2];
 }


### PR DESCRIPTION
```
uint16_t reg = read_cmos_register(dev, 0x0106);
if (reg < 0)
```

'reg' never be < 0. If read_cmos_register() failed it return value < 0, reg = 0xffff - err_value + 1

In read_cmos_register() send_cmd() if failed can return -1 or LIBUSB_ERROR_OTHER(-99) therefore read_cmos_register() must return only -1 if failed for correct result check
