### PR TITLE
Remove C99 syntax from fakenect.c

### DIFF
--- a/fakenect/fakenect.c
+++ b/fakenect/fakenect.c
@@ -96,9 +96,10 @@ static double get_time()
 
 static char *one_line(FILE *fp)
 {
+	int c;
 	int pos = 0;
 	char *out = NULL;
-	for (int c = fgetc(fp); !(c == '\n' || c == EOF); c = fgetc(fp))
+	for (c = fgetc(fp); !(c == '\n' || c == EOF); c = fgetc(fp))
 	{
 		out = realloc(out, pos + 1);
 		out[pos++] = c;


### PR DESCRIPTION
Recent commit a05075a1bda356a79c3eeddcc4eab1ac20008425 uses C99 syntax
on line 101 of fakenect.c:

```
for (int c = /* snip */
```

However, the build system compiles (at least on my machine) using C89,
causing the build to fail. Moving the declaration of int c to the top
of the function solves the problem.
