### PR TITLE
Bugfix for multiple K4W or 1473 devices needing keep_alive. 

### DIFF
--- a/src/freenect_internal.h
+++ b/src/freenect_internal.h
@@ -45,6 +45,9 @@ typedef void (*fnusb_iso_cb)(freenect_device *dev, uint8_t *buf, int len);
 
 #include "usb_libusb10.h"
 
+//needed to set the led state for non 1414 devices - replaces keep_alive.c
+FN_INTERNAL int fnusb_set_led_alt(libusb_device_handle * dev, freenect_context * ctx, freenect_led_options state);
+
 struct _freenect_context {
 	freenect_loglevel log_level;
 	freenect_log_cb log_cb;

--- a/src/tilt.c
+++ b/src/tilt.c
@@ -243,11 +243,9 @@ int freenect_set_tilt_degs(freenect_device *dev, double angle)
 	return ret;
 }
 
-#ifdef BUILD_AUDIO
-int freenect_set_led_alt(freenect_device *dev, freenect_led_options state)
-{
-	freenect_context *ctx = dev->parent;
 
+FN_INTERNAL int fnusb_set_led_alt(libusb_device_handle * dev, freenect_context * ctx, freenect_led_options state)
+{
     typedef enum {
         LED_ALT_OFF = 1,
         LED_ALT_BLINK_GREEN = 2,
@@ -283,12 +281,19 @@ int freenect_set_led_alt(freenect_device *dev, freenect_led_options state)
 	unsigned char buffer[20];
 	memcpy(buffer, &cmd, 20);
     
-	res = libusb_bulk_transfer(dev->usb_audio.dev, 0x01, buffer, 20, &transferred, 0);
+	res = libusb_bulk_transfer(dev, 0x01, buffer, 20, &transferred, 0);
 	if (res != 0) {
-		FN_WARNING("freenect_set_led_alt(): libusb_bulk_transfer failed: %d (transferred = %d)\n", res, transferred);
+		FN_WARNING("fnusb_set_led_alt(): libusb_bulk_transfer failed: %d (transferred = %d)\n", res, transferred);
 		return res;
 	}
-	return get_reply(dev->usb_audio.dev, ctx);
+	return get_reply(dev, ctx);
+}
+
+#ifdef BUILD_AUDIO
+int freenect_set_led_alt(freenect_device *dev, freenect_led_options state)
+{
+	freenect_context *ctx = dev->parent;
+    return fnusb_set_led_alt(dev->usb_audio.dev, ctx, state);
 }
 #endif
 


### PR DESCRIPTION
Opening by PID fails when multiple identical devices are on the system ( i.e.: if there are two Kinect 1473 libusb_open_device_with_vid_pid has no way to know which audio device to open. 

This PR uses the newer `libusb_get_parent` and `lib_usb_get_bus_number` to get the correct audio device for a camera. 

PR is backwards compatible with older versions of libusb so it only applies the newer method if libusb >= 1.0.18 is detected. At a later date we can assume 1.0.18 or higher and remove the keep_alive.c files. 

Signed-off-by: Theodore Watson theo@openframeworks.cc (ofTheo)
