### PR TITLE
Fix fakenect not handling freenect_process_events_timeout

### DIFF
--- a/fakenect/fakenect.c
+++ b/fakenect/fakenect.c
@@ -203,6 +203,11 @@ int freenect_process_events(freenect_context *ctx)
 	return 0;
 }
 
+int freenect_process_events_timeout(freenect_context *ctx, struct timeval *timeout)
+{
+	return freenect_process_events(ctx);
+}
+
 double freenect_get_tilt_degs(freenect_raw_tilt_state *state)
 {
 	// NOTE: This is duped from tilt.c, this is the only function we need from there


### PR DESCRIPTION
I used libfreenect for the first time and fakenect wouldn't work without this little fix. I know it's not elegant, but it does work. Playback is not very smooth, and I'm not sure if that has anything to do with the way this was fixed, so if someone got a minute, please have a look.
