### PR TITLE
Allow freenect_set_tilt_degs to take a negative angle

### DIFF
--- a/src/tilt.c
+++ b/src/tilt.c
@@ -239,7 +239,7 @@ int freenect_set_tilt_degs(freenect_device *dev, double angle)
 	angle = (angle<MIN_TILT_ANGLE) ? MIN_TILT_ANGLE : ((angle>MAX_TILT_ANGLE) ? MAX_TILT_ANGLE : angle);
 	angle = angle * 2;
 
-	ret = fnusb_control(&dev->usb_motor, 0x40, 0x31, (uint16_t)angle, 0x0, empty, 0x0);
+	ret = fnusb_control(&dev->usb_motor, 0x40, 0x31, (int16_t)angle, 0x0, empty, 0x0);
 	return ret;
 }
 


### PR DESCRIPTION
I can't set a negative angle using gcc 4.8.2 for ARM since negative double values get clamped to 0x0 when casted to uint16_t, as one would expect. Oddly it works on a x86_64 build.

Fix the issue by casting the double to int16_t instead.
