### PR TITLE
python: make all cv examples to work with cv2

### DIFF
--- a/wrappers/python/demo_cv2_async.py
+++ b/wrappers/python/demo_cv2_async.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+import freenect
+import cv2
+import frame_convert2
+
+cv2.namedWindow('Depth')
+cv2.namedWindow('RGB')
+keep_running = True
+
+
+def display_depth(dev, data, timestamp):
+    global keep_running
+    cv2.imshow('Depth', frame_convert2.pretty_depth_cv(data))
+    if cv2.waitKey(10) == 27:
+        keep_running = False
+
+
+def display_rgb(dev, data, timestamp):
+    global keep_running
+    cv2.imshow('RGB', frame_convert2.video_cv(data))
+    if cv2.waitKey(10) == 27:
+        keep_running = False
+
+
+def body(*args):
+    if not keep_running:
+        raise freenect.Kill
+
+
+print('Press ESC in window to stop')
+freenect.runloop(depth=display_depth,
+                 video=display_rgb,
+                 body=body)

--- a/wrappers/python/demo_cv2_sync.py
+++ b/wrappers/python/demo_cv2_sync.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import freenect
+import cv2
+import frame_convert2
+
+cv2.namedWindow('Depth')
+cv2.namedWindow('Video')
+print('Press ESC in window to stop')
+
+
+def get_depth():
+    return frame_convert2.pretty_depth_cv(freenect.sync_get_depth()[0])
+
+
+def get_video():
+    return frame_convert2.video_cv(freenect.sync_get_video()[0])
+
+
+while 1:
+    cv2.imshow('Depth', get_depth())
+    cv2.imshow('Video', get_video())
+    if cv2.waitKey(10) == 27:
+        break

--- a/wrappers/python/demo_cv2_sync_multi.py
+++ b/wrappers/python/demo_cv2_sync_multi.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""This goes through each kinect on your system, grabs one frame and
+displays it.  Uncomment the commented line to shut down after each frame
+if your system can't handle it (will get very low FPS but it should work).
+This will keep trying indeces until it finds one that doesn't work, then it
+starts from 0.
+"""
+import freenect
+import cv2
+import frame_convert2
+
+cv2.namedWindow('Depth')
+cv2.namedWindow('Video')
+ind = 0
+print('%s\nPress ESC to stop' % __doc__)
+
+
+def get_depth(ind):
+    return frame_convert2.pretty_depth_cv(freenect.sync_get_depth(ind)[0])
+
+
+def get_video(ind):
+    return frame_convert2.video_cv(freenect.sync_get_video(ind)[0])
+
+
+while 1:
+    print(ind)
+    try:
+        depth = get_depth(ind)
+        video = get_video(ind)
+    except TypeError:
+        ind = 0
+        continue
+    ind += 1
+    cv2.imshow('Depth', depth)
+    cv2.imshow('Video', video)
+    if cv2.waitKey(10) == 27:
+        break
+    #freenect.sync_stop()  # NOTE: Uncomment if your machine can't handle it

--- a/wrappers/python/demo_cv2_thresh_sweep.py
+++ b/wrappers/python/demo_cv2_thresh_sweep.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""Sweeps throught the depth image showing 100 range at a time"""
+import freenect
+import cv2
+import numpy as np
+import time
+
+cv2.namedWindow('Depth')
+
+
+def disp_thresh(lower, upper):
+    depth, timestamp = freenect.sync_get_depth()
+    depth = 255 * np.logical_and(depth > lower, depth < upper)
+    depth = depth.astype(np.uint8)
+    cv2.imshow('Depth', depth)
+    cv2.waitKey(10)
+
+
+lower = 0
+upper = 100
+max_upper = 2048
+while upper < max_upper:
+    print('%d < depth < %d' % (lower, upper))
+    disp_thresh(lower, upper)
+    time.sleep(.1)
+    lower += 20
+    upper += 20

--- a/wrappers/python/demo_cv2_threshold.py
+++ b/wrappers/python/demo_cv2_threshold.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+import freenect
+import cv2
+import frame_convert2
+import numpy as np
+
+
+threshold = 100
+current_depth = 0
+
+
+def change_threshold(value):
+    global threshold
+    threshold = value
+
+
+def change_depth(value):
+    global current_depth
+    current_depth = value
+
+
+def show_depth():
+    global threshold
+    global current_depth
+
+    depth, timestamp = freenect.sync_get_depth()
+    depth = 255 * np.logical_and(depth >= current_depth - threshold,
+                                 depth <= current_depth + threshold)
+    depth = depth.astype(np.uint8)
+    cv2.imshow('Depth', depth)
+
+
+def show_video():
+    cv2.imshow('Video', frame_convert2.video_cv(freenect.sync_get_video()[0]))
+
+
+cv2.namedWindow('Depth')
+cv2.namedWindow('Video')
+cv2.createTrackbar('threshold', 'Depth', threshold,     500,  change_threshold)
+cv2.createTrackbar('depth',     'Depth', current_depth, 2048, change_depth)
+
+print('Press ESC in window to stop')
+
+
+while 1:
+    show_depth()
+    show_video()
+    if cv2.waitKey(10) == 27:
+        break

--- a/wrappers/python/frame_convert2.py
+++ b/wrappers/python/frame_convert2.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+
+def pretty_depth(depth):
+    """Converts depth into a 'nicer' format for display
+
+    This is abstracted to allow for experimentation with normalization
+
+    Args:
+        depth: A numpy array with 2 bytes per pixel
+
+    Returns:
+        A numpy array that has been processed with unspecified datatype
+    """
+    np.clip(depth, 0, 2**10 - 1, depth)
+    depth >>= 2
+    depth = depth.astype(np.uint8)
+    return depth
+
+
+def pretty_depth_cv(depth):
+    """Converts depth into a 'nicer' format for display
+
+    This is abstracted to allow for experimentation with normalization
+
+    Args:
+        depth: A numpy array with 2 bytes per pixel
+
+    Returns:
+        A numpy array with unspecified datatype
+    """
+    return pretty_depth(depth)
+
+
+def video_cv(video):
+    """Converts video into a BGR format for display
+
+    This is abstracted out to allow for experimentation
+
+    Args:
+        video: A numpy array with 1 byte per pixel, 3 channels RGB
+
+    Returns:
+        A numpy array with with 1 byte per pixel, 3 channels BGR
+    """
+    return video[:, :, ::-1]  # RGB -> BGR


### PR DESCRIPTION
The latest OpenCV interface for python, cv2, is incompatible with the original interface cv.  I convert all the cv examples to work with cv2.