### PR TITLE
Make recorded OniFile usable with NiTE2

### DIFF
--- a/OpenNI2-FreenectDriver/src/DepthStream.hpp
+++ b/OpenNI2-FreenectDriver/src/DepthStream.hpp
@@ -206,5 +206,59 @@ namespace FreenectDriver
           return ONI_STATUS_OK;
       }
     }
+    
+    
+    void notifyAllProperties()
+    {
+      
+      double nDouble;
+	    int size = sizeof(nDouble);
+            
+	    getProperty(XN_STREAM_PROPERTY_EMITTER_DCMOS_DISTANCE, &nDouble, &size);
+	    raisePropertyChanged(XN_STREAM_PROPERTY_EMITTER_DCMOS_DISTANCE, &nDouble, size);
+
+
+	    unsigned long long nUll;
+	    size = sizeof(nUll);
+	    getProperty(XN_STREAM_PROPERTY_ZERO_PLANE_PIXEL_SIZE, &nUll, &size);
+	    raisePropertyChanged(XN_STREAM_PROPERTY_ZERO_PLANE_PIXEL_SIZE, &nUll, size);
+
+	    getProperty(XN_STREAM_PROPERTY_GAIN, &nUll, &size);
+	    raisePropertyChanged(XN_STREAM_PROPERTY_GAIN, &nUll, size);
+	    
+	    getProperty(XN_STREAM_PROPERTY_CONST_SHIFT, &nUll, &size);
+	    raisePropertyChanged(XN_STREAM_PROPERTY_CONST_SHIFT, &nUll, size);
+	  
+	    getProperty(XN_STREAM_PROPERTY_MAX_SHIFT, &nUll, &size);
+	    raisePropertyChanged(XN_STREAM_PROPERTY_MAX_SHIFT, &nUll, size);
+	    
+	    getProperty(XN_STREAM_PROPERTY_SHIFT_SCALE, &nUll, &size);
+	    raisePropertyChanged(XN_STREAM_PROPERTY_SHIFT_SCALE, &nUll, size);
+	      
+	    getProperty(XN_STREAM_PROPERTY_ZERO_PLANE_DISTANCE, &nUll, &size);
+	    raisePropertyChanged(XN_STREAM_PROPERTY_ZERO_PLANE_DISTANCE, &nUll, size);
+	    
+	    getProperty(XN_STREAM_PROPERTY_PARAM_COEFF, &nUll, &size);
+	    raisePropertyChanged(XN_STREAM_PROPERTY_PARAM_COEFF, &nUll, size);
+	    
+	    int nInt;
+	    size = sizeof(nInt);
+
+
+	    getProperty(ONI_STREAM_PROPERTY_MAX_VALUE, &nInt, &size);
+	    raisePropertyChanged(ONI_STREAM_PROPERTY_MAX_VALUE, &nInt, size);
+
+	    unsigned short nBuff[10001];
+	    size = sizeof(S2D);
+	    getProperty(XN_STREAM_PROPERTY_S2D_TABLE, nBuff, &size);
+	    raisePropertyChanged(XN_STREAM_PROPERTY_S2D_TABLE, nBuff, size);
+	
+	    size = sizeof(D2S);
+	    getProperty(XN_STREAM_PROPERTY_D2S_TABLE, nBuff, &size);
+	    raisePropertyChanged(XN_STREAM_PROPERTY_D2S_TABLE, nBuff, size);
+	    VideoStream::notifyAllProperties();
+    }
+
+
   };
 }


### PR DESCRIPTION
added DepthStream::notifyAll() in the OpenNI2-FreenectDriver, so that all stream properties can be stored by OniRecorder into .oni file for the kinect sensor. 
Now NiTE2 is working also with sequences recorded from OpenNI2-FreenectDriver and read with OniFile driver (before it was complaining that some properties were missing).