### PR TITLE
Python 3 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@
 ######################################################################################
 
 cmake_minimum_required(VERSION 2.6)
-set(PYTHON_EXECUTABLE "python2")
 
 ######################################################################################
 # Project declaration and options
@@ -61,7 +60,9 @@ OPTION(BUILD_C_SYNC "Build c synchronous library" ON)
 OPTION(BUILD_CPP "Build C++ Library (currently header only)" ON)
 OPTION(BUILD_CV "Build OpenCV wrapper" OFF)
 OPTION(BUILD_AS3_SERVER "Build the Actionscript 3 Server Example" OFF)
-OPTION(BUILD_PYTHON "Build Python extension" OFF)
+OPTION(BUILD_PYTHON "Build Python extensions" OFF)
+OPTION(BUILD_PYTHON2 "Build Python 2 extension" OFF)
+OPTION(BUILD_PYTHON3 "Build Python 3 extension" OFF)
 OPTION(BUILD_OPENNI2_DRIVER "Build libfreenect driver for OpenNI2" OFF)
 IF(PROJECT_OS_LINUX)
 	OPTION(BUILD_CPACK_DEB "Build an DEB using CPack" OFF)
@@ -157,6 +158,10 @@ IF(BUILD_AS3_SERVER)
 ENDIF()
 
 IF(BUILD_PYTHON)
+  set(BUILD_PYTHON2 ON)
+  set(BUILD_PYTHON3 ON)
+ENDIF()
+IF(BUILD_PYTHON2 OR BUILD_PYTHON3)
   add_subdirectory (wrappers/python)
 ENDIF()
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To build libfreenect, you'll need
 
 - [libusb](http://libusb.info) >= 1.0.18
 - [CMake](http://cmake.org) >= 2.6
-- [python](http://python.org) == 2.* (only if BUILD_PYTHON=ON or BUILD_REDIST_PACKAGE=OFF)
+- [python](http://python.org) >= 2.7 or >= 3.3 (only if BUILD_PYTHON=ON or BUILD_PYTHON2=ON or BUILD_PYTHON3=ON or BUILD_REDIST_PACKAGE=OFF)
 
 For the examples, you'll need
 

--- a/src/fwfetcher.py
+++ b/src/fwfetcher.py
@@ -197,7 +197,7 @@ def do_utime(targetname, atime, mtime):
         # Using utime() on directories is not allowed on Win32 according to
         # msdn.microsoft.com
         os.utime(targetname,
-            (time.mktime(mstime(atime)), time.mktime(mstime(mtime))))
+                 (time.mktime(mstime(atime)), time.mktime(mstime(mtime))))
 
 ###############################################################################
 
@@ -246,7 +246,7 @@ def get_cluster(startclust, offset):
 ###############################################################################
 
 def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
-        offset):
+                   offset):
     """Fill the directory structure with the files contained in the archive.
 
        @param infile pointer to the archive
@@ -262,9 +262,9 @@ def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
 
     # dictionary which holds the directory structure,
     # patch 0xFFFF is the 'root' directory.
-    paths = {0xFFFF:""}
+    paths = {0xFFFF: ""}
 
-    oldpathind = 0xFFFF # initial path, speed up file/dir creation
+    oldpathind = 0xFFFF  # initial path, speed up file/dir creation
 
     for i in xrange(0x1000 * firstclust // 64):
         cur = contents[i * 64:(i + 1) * 64]
@@ -286,7 +286,7 @@ def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
         if nlen < 1 or nlen > 40:
             print "Filename length (%i) out of range, skipping file." % nlen
             continue
-        outname = outname[0:nlen] # strip trailing 0x00 from filename
+        outname = outname[0:nlen]  # strip trailing 0x00 from filename
 
         if txtfile != None:
             if namelen & 0x80 == 0x80:
@@ -312,7 +312,7 @@ def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
         if pathind != oldpathind:
             # working directory changed
             for _ in xrange(paths[oldpathind].count("/")):
-                os.chdir("..") # go back to root directory
+                os.chdir("..")  # go back to root directory
             os.chdir(paths[pathind])
             oldpathind = pathind
         if namelen & 0x80 == 0x80:
@@ -358,8 +358,9 @@ def write_common_part(infile, txtfile, png2stop, start):
     """
 
     infile.seek(0x32C)
-    mhash = infile.read(20) # xbox180 : SHA1 hash of 0x0344-0xB000,
-                            # CON : 0x0344 - 0xA000 (i.e. png2stop)
+    # xbox180 : SHA1 hash of 0x0344-0xB000,
+    # CON : 0x0344 - 0xA000 (i.e. png2stop)
+    mhash = infile.read(20)
     (mentry_id, content_type) = struct.unpack(">LL", infile.read(8))
 
     if txtfile != None:
@@ -488,14 +489,14 @@ def handle_live_pirs(infile, fsize):
             print >> txtfile, hex(ord(i)),
         print >> txtfile
 
-    ### BEGIN wxPirs ###
-    infile.seek(0xC032) # originally 4 bytes at 0xC030
+    # BEGIN wxPirs
+    infile.seek(0xC032)  # originally 4 bytes at 0xC030
     (pathind, ) = struct.unpack(">H", infile.read(2))
     if pathind == 0xFFFF:
-        start  = 0xC000
+        start = 0xC000
     else:
-        start  = 0xD000
-    ### END wxPirs ###
+        start = 0xD000
+    # END wxPirs
     write_common_part(infile, txtfile, 0xB000, start)
 
 ###############################################################################
@@ -535,7 +536,7 @@ def extractPirsFromZip(systemupdate):
     print "Extracting $SystemUpdate/FFFE07DF00000001 from system update file..."
     updatefile = StringIO.StringIO(systemupdate)
     z = zipfile.ZipFile(updatefile)
-    #print z.namelist()
+    # print z.namelist()
     pirs = z.open("$SystemUpdate/FFFE07DF00000001").read()
     print "done."
     return pirs
@@ -555,7 +556,7 @@ if __name__ == "__main__":
         basename = "FFFE07DF00000001"
         sio.name = basename
         pwd = os.getcwd()
-        handle_live_pirs(sio, len(pirs)-4)
+        handle_live_pirs(sio, len(pirs) - 4)
 
         os.chdir(pwd)
         print "Moving audios.bin to current folder"

--- a/src/fwfetcher.py
+++ b/src/fwfetcher.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from urllib2 import Request, urlopen, URLError
 import hashlib
 import os
 import StringIO
@@ -10,6 +9,13 @@ import struct
 import sys
 import time
 import zipfile
+
+try:
+    # Python 3
+    from urllib.request import Request, URLError, urlopen
+except ImportError:
+    # Python 2
+    from urllib2 import Request, URLError, urlopen
 
 # fwfetcher.py - a program to extract the Kinect audio firmware from an Xbox360
 # system update.  This program includes substantial portions of extract360.py,

--- a/src/fwfetcher.py
+++ b/src/fwfetcher.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 from urllib2 import Request, urlopen, URLError
 import hashlib
@@ -175,8 +175,8 @@ def mstime(intime):
        @return the time tuple
     """
 
-    num_d = (intime & 0xFFFF0000L) >> 16
-    num_t = intime & 0x0000FFFFL
+    num_d = (intime & 0xFFFF0000) >> 16
+    num_t = intime & 0x0000FFFF
     # format below is : year, month, day, hour, minute, second,
     #                   weekday (Monday), yearday (unused), DST flag (guess)
     return ((num_d >> 9) + 1980, (num_d >> 5) & 0x0F, num_d & 0x1F,

--- a/src/fwfetcher.py
+++ b/src/fwfetcher.py
@@ -503,71 +503,71 @@ def handle_live_pirs(infile, fsize):
 # End of code taken from extract360.py.
 
 def getFileOrURL(filename, url):
-	# Check if a file named filename exists on disk.
-	# If so, return its contents.  If not, download it, save it, and return its contents.
-	try:
-		f = open(filename)
-		print "Found", filename, "cached on disk, using local copy"
-		retval = f.read()
-		return retval
-	except IOError, e:
-		pass
-	print "Downloading", filename, "from", url
-	req = Request(url)
-	try:
-		response = urlopen(req)
-	except URLError, e:
-		if hasattr(e, 'reason'):
-			print "Failed to reach download server.  Reason:", e.reason
-		elif hasattr(e, 'code'):
-			print "The server couldn't fulfill the request.  Error code:", e.code
-	print "Reading response..."
-	retval = response.read()
-	# Save downloaded file to disk
-	f = open(filename, "wb")
-	f.write(retval)
-	f.close()
-	print "done, saved to", filename
-	return retval
+    # Check if a file named filename exists on disk.
+    # If so, return its contents.  If not, download it, save it, and return its contents.
+    try:
+        f = open(filename)
+        print "Found", filename, "cached on disk, using local copy"
+        retval = f.read()
+        return retval
+    except IOError, e:
+        pass
+    print "Downloading", filename, "from", url
+    req = Request(url)
+    try:
+        response = urlopen(req)
+    except URLError, e:
+        if hasattr(e, 'reason'):
+            print "Failed to reach download server.  Reason:", e.reason
+        elif hasattr(e, 'code'):
+            print "The server couldn't fulfill the request.  Error code:", e.code
+    print "Reading response..."
+    retval = response.read()
+    # Save downloaded file to disk
+    f = open(filename, "wb")
+    f.write(retval)
+    f.close()
+    print "done, saved to", filename
+    return retval
 
 def extractPirsFromZip(systemupdate):
-	print "Extracting $SystemUpdate/FFFE07DF00000001 from system update file..."
-	updatefile = StringIO.StringIO(systemupdate)
-	z = zipfile.ZipFile(updatefile)
-	#print z.namelist()
-	pirs = z.open("$SystemUpdate/FFFE07DF00000001").read()
-	print "done."
-	return pirs
+    print "Extracting $SystemUpdate/FFFE07DF00000001 from system update file..."
+    updatefile = StringIO.StringIO(systemupdate)
+    z = zipfile.ZipFile(updatefile)
+    #print z.namelist()
+    pirs = z.open("$SystemUpdate/FFFE07DF00000001").read()
+    print "done."
+    return pirs
 
 if __name__ == "__main__":
-	target = "audios.bin"
-	if len(sys.argv) == 2:
-		target = sys.argv[1]
-	if not os.path.isfile(target):
-		fw = getFileOrURL("SystemUpdate.zip", "http://www.xbox.com/system-update-usb")
-		pirs = extractPirsFromZip(fw)
+    target = "audios.bin"
+    if len(sys.argv) == 2:
+        target = sys.argv[1]
+    if not os.path.isfile(target):
+        fw = getFileOrURL("SystemUpdate.zip", "http://www.xbox.com/system-update-usb")
+        pirs = extractPirsFromZip(fw)
 
-		lang = ["English", "Japanese", "German", "French", "Spanish", "Italian",
-				            "Korean", "Chinese", "Portuguese"]
-		sio = StringIO.StringIO(pirs)
-		basename = "FFFE07DF00000001"
-		sio.name = basename
-		pwd = os.getcwd()
-		handle_live_pirs(sio, len(pirs)-4)
+        lang = ["English", "Japanese", "German", "French", "Spanish", "Italian",
+                "Korean", "Chinese", "Portuguese"]
+        sio = StringIO.StringIO(pirs)
+        basename = "FFFE07DF00000001"
+        sio.name = basename
+        pwd = os.getcwd()
+        handle_live_pirs(sio, len(pirs)-4)
 
-		os.chdir(pwd)
-		print "Moving audios.bin to current folder"
-		os.rename(os.path.join(basename + ".dir", "audios.bin"), target)
+        os.chdir(pwd)
+        print "Moving audios.bin to current folder"
+        os.rename(os.path.join(basename + ".dir", "audios.bin"), target)
 
-		print "Cleaning up"
-		os.unlink(basename + ".txt")
-		for root, dirs, files in os.walk(basename + ".dir"):
-			for name in files:
-				os.remove(os.path.join(root, name))
-			for name in dirs:
-				os.rmdir(os.path.join(root, name))
-			os.rmdir(root)
-		os.unlink("SystemUpdate.zip")
-		print "Done!"
-	else:
-		print "Already have audios.bin"
+        print "Cleaning up"
+        os.unlink(basename + ".txt")
+        for root, dirs, files in os.walk(basename + ".dir"):
+            for name in files:
+                os.remove(os.path.join(root, name))
+            for name in dirs:
+                os.rmdir(os.path.join(root, name))
+            os.rmdir(root)
+        os.unlink("SystemUpdate.zip")
+        print "Done!"
+    else:
+        print "Already have audios.bin"

--- a/src/fwfetcher.py
+++ b/src/fwfetcher.py
@@ -297,7 +297,7 @@ def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
             continue
         outname = outname[0:nlen]  # strip trailing 0x00 from filename
 
-        if txtfile != None:
+        if txtfile is not None:
             if namelen & 0x80 == 0x80:
                 print("Directory", end=' ', file=txtfile)
             else:
@@ -332,7 +332,7 @@ def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
             # this is a file
             # space between files is set to 0x00
             adstart = startclust * 0x1000 + start
-            if txtfile != None:
+            if txtfile is not None:
                 print("Starting: advertized", hex(adstart), file=txtfile)
 
             # block reading algorithm originally from wxPirs
@@ -372,7 +372,7 @@ def write_common_part(infile, txtfile, png2stop, start):
     mhash = infile.read(20)
     (mentry_id, content_type) = struct.unpack(">LL", infile.read(8))
 
-    if txtfile != None:
+    if txtfile is not None:
         print("\nMaster SHA1 hash :",
               check_sha1(mhash, mentry_id, infile, 0x0344, png2stop),
               file=txtfile)
@@ -415,7 +415,7 @@ def write_common_part(infile, txtfile, png2stop, start):
               file=txtfile)
     infile.seek(0x1710)
     (val1, png1len, png2len) = struct.unpack(">HLL", infile.read(10))
-    if txtfile != None:
+    if txtfile is not None:
         print("Value:", val1, file=txtfile)
 
     if png1len > 0:
@@ -446,7 +446,7 @@ def write_common_part(infile, txtfile, png2stop, start):
     fill_directory(infile, txtfile, buf, firstclust, makedir, start, offset)
 
     # table of SHA1 hashes of payload
-    if txtfile != None:
+    if txtfile is not None:
         print(file=txtfile)
         infile.seek(png2stop)
         buf = infile.read(start - png2stop)
@@ -489,7 +489,7 @@ def handle_live_pirs(infile, fsize):
         return
 
     txtfile = open_info_file(infile)
-    if txtfile != None:
+    if txtfile is not None:
         print("Certificate (hex):", end=' ', file=txtfile)
         cert = infile.read(0x100)
         for i in cert:

--- a/src/fwfetcher.py
+++ b/src/fwfetcher.py
@@ -89,9 +89,9 @@ def do_mkdir(dirname):
 
     try:
         os.mkdir(dirname)
-    except OSError, (errno):
-        if errno == 17:
-            pass # directory already exists
+    except OSError as e:
+        if e.errno == 17:
+            pass  # directory already exists
 
 ###############################################################################
 
@@ -518,13 +518,13 @@ def getFileOrURL(filename, url):
         print("Found", filename, "cached on disk, using local copy")
         retval = f.read()
         return retval
-    except IOError, e:
+    except IOError:
         pass
     print("Downloading", filename, "from", url)
     req = Request(url)
     try:
         response = urlopen(req)
-    except URLError, e:
+    except URLError as e:
         if hasattr(e, 'reason'):
             print("Failed to reach download server.  Reason:", e.reason)
         elif hasattr(e, 'code'):

--- a/src/fwfetcher.py
+++ b/src/fwfetcher.py
@@ -27,6 +27,12 @@ import zipfile
    Note that it dumps UTF-16 characters in text strings as-is.
 """
 
+
+# Minor compatibility shim
+if sys.version_info[0] < 3:
+    input = raw_input
+    range = xrange
+
 ###############################################################################
 
 def check_size(fsize, minsize):
@@ -54,7 +60,7 @@ def nice_open_file(filename):
 
     if os.path.isfile(filename):
         print(filename, "already exists, overwrite? (y/n)", end=' ')
-        answer = raw_input("")
+        answer = input("")
         return len(answer) > 0 and answer[0] in ["Y", "y"]
     else:
         return True
@@ -73,7 +79,7 @@ def nice_open_dir(dirname):
     if os.path.isdir(dirname):
         print(dirname, "already exists, ok to overwrite files in it? (y/n)",
               end=' ')
-        answer = raw_input("")
+        answer = input("")
         return len(answer) > 0 and answer[0] in ["Y", "y"]
     else:
         return True
@@ -161,7 +167,7 @@ def dump_info(infile, txtfile, what):
     """
 
     print("\n", what, ":", file=txtfile)
-    for i in xrange(9):
+    for i in range(9):
         info = strip_blanks(infile.read(0x100))
         if len(info) > 0:
             print(lang[i], ":", info, file=txtfile)
@@ -269,7 +275,7 @@ def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
 
     oldpathind = 0xFFFF  # initial path, speed up file/dir creation
 
-    for i in xrange(0x1000 * firstclust // 64):
+    for i in range(0x1000 * firstclust // 64):
         cur = contents[i * 64:(i + 1) * 64]
         if ord(cur[40]) == 0:
             # if filename length is zero, we're done
@@ -314,7 +320,7 @@ def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
 
         if pathind != oldpathind:
             # working directory changed
-            for _ in xrange(paths[oldpathind].count("/")):
+            for _ in range(paths[oldpathind].count("/")):
                 os.chdir("..")  # go back to root directory
             os.chdir(paths[pathind])
             oldpathind = pathind
@@ -345,7 +351,7 @@ def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
         do_utime(outname, dati2, dati1)
 
     # pop directory
-    for _ in xrange(paths[oldpathind].count("/")):
+    for _ in range(paths[oldpathind].count("/")):
         os.chdir("..")
 
 ###############################################################################
@@ -445,14 +451,14 @@ def write_common_part(infile, txtfile, png2stop, start):
         infile.seek(png2stop)
         buf = infile.read(start - png2stop)
         numempty = 0
-        for i in xrange(len(buf) // 24):
+        for i in range(len(buf) // 24):
             entry = buf[i * 24: i * 24 + 24]
             if entry.count("\0") < 24:
                 if numempty > 0:
                     print("\nEmpty entries:", numempty, file=txtfile)
                     numempty = 0
                 print("Hash (hex):", end=' ', file=txtfile)
-                for j in xrange(20):
+                for j in range(20):
                     print(hex(ord(entry[j])), end=' ', file=txtfile)
                 (j, ) = struct.unpack(">L", entry[20:24])
                 print("\nEntry id:", hex(j), file=txtfile)

--- a/src/fwfetcher.py
+++ b/src/fwfetcher.py
@@ -25,7 +25,7 @@ import zipfile
    Note that it dumps UTF-16 characters in text strings as-is.
 """
 
-################################################################################
+###############################################################################
 
 def check_size(fsize, minsize):
     """Ensure that the filesize is at least minsize bytes.
@@ -40,7 +40,7 @@ def check_size(fsize, minsize):
             (fsize, minsize)
     return fsize >= minsize
 
-################################################################################
+###############################################################################
 
 def nice_open_file(filename):
     """Checks if the output file with the given name already exists,
@@ -57,7 +57,7 @@ def nice_open_file(filename):
     else:
         return True
 
-################################################################################
+###############################################################################
 
 def nice_open_dir(dirname):
     """Checks if the output directory with the given name already exists,
@@ -75,7 +75,7 @@ def nice_open_dir(dirname):
     else:
         return True
 
-################################################################################
+###############################################################################
 
 def do_mkdir(dirname):
     """Version of os.mkdir() which does not throw an exception if the directory
@@ -90,7 +90,7 @@ def do_mkdir(dirname):
         if errno == 17:
             pass # directory already exists
 
-################################################################################
+###############################################################################
 
 def strip_blanks(instring):
     """Strip the leading and trailing blanks from the input string.
@@ -103,7 +103,7 @@ def strip_blanks(instring):
     rstr = instring.rstrip("\0 \t\n\r\v\f\377")
     return rstr.lstrip(" \t\n\r\v\f\377")
 
-################################################################################
+###############################################################################
 
 def open_info_file(infile):
     """Open the informational text file.
@@ -122,7 +122,7 @@ def open_info_file(infile):
     else:
         return None
 
-################################################################################
+###############################################################################
 
 def dump_png(infile, pnglen, maxlen, pngid):
     """Dump the embedded PNG file from the archive file to an output file.
@@ -146,7 +146,7 @@ def dump_png(infile, pnglen, maxlen, pngid):
         print "PNG image %s too large (%i instead of maximal %i bytes), " \
             "file not written." % (pngid, pnglen, maxlen)
 
-################################################################################
+###############################################################################
 
 def dump_info(infile, txtfile, what):
     """Dumps the 9 information strings from the input file.
@@ -163,7 +163,7 @@ def dump_info(infile, txtfile, what):
         if len(info) > 0:
             print >> txtfile, lang[i], ":", info
 
-################################################################################
+###############################################################################
 
 def mstime(intime):
     """Convert the time given in Microsoft format to a normal time tuple.
@@ -180,7 +180,7 @@ def mstime(intime):
             (num_t & 0xFFFF) >> 11, (num_t >> 5) & 0x3F, (num_t & 0x1F) * 2,
             0, 0, -1)
 
-################################################################################
+###############################################################################
 
 def do_utime(targetname, atime, mtime):
     """Set the access and update date/time of the target.
@@ -199,7 +199,7 @@ def do_utime(targetname, atime, mtime):
         os.utime(targetname,
             (time.mktime(mstime(atime)), time.mktime(mstime(mtime))))
 
-################################################################################
+###############################################################################
 
 def check_sha1(sha1, entry, infile, start, end):
     """Check the SHA1 value of the specified range of the input file.
@@ -231,7 +231,7 @@ def check_sha1(sha1, entry, infile, start, end):
         return ret + "wrong (should be " + hexdig + " actual " + \
             found_sha1.hexdigest() + ")"
 
-################################################################################
+###############################################################################
 
 def get_cluster(startclust, offset):
     """get the real starting cluster"""
@@ -243,7 +243,7 @@ def get_cluster(startclust, offset):
     # END wxPirs
     return rst
 
-################################################################################
+###############################################################################
 
 def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
         offset):
@@ -345,7 +345,7 @@ def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
     for _ in xrange(paths[oldpathind].count("/")):
         os.chdir("..")
 
-################################################################################
+###############################################################################
 
 def write_common_part(infile, txtfile, png2stop, start):
     """Writes out the common part of PIRS/LIVE and CON files.
@@ -459,7 +459,7 @@ def write_common_part(infile, txtfile, png2stop, start):
 
         txtfile.close()
 
-################################################################################
+###############################################################################
 
 def handle_live_pirs(infile, fsize):
     """LIVE and PIRS files are archive files.
@@ -498,13 +498,14 @@ def handle_live_pirs(infile, fsize):
     ### END wxPirs ###
     write_common_part(infile, txtfile, 0xB000, start)
 
-################################################################################
+###############################################################################
 
 # End of code taken from extract360.py.
 
 def getFileOrURL(filename, url):
     # Check if a file named filename exists on disk.
-    # If so, return its contents.  If not, download it, save it, and return its contents.
+    # If so, return its contents.  If not, download it, save it, and return its
+    # contents.
     try:
         f = open(filename)
         print "Found", filename, "cached on disk, using local copy"
@@ -544,11 +545,12 @@ if __name__ == "__main__":
     if len(sys.argv) == 2:
         target = sys.argv[1]
     if not os.path.isfile(target):
-        fw = getFileOrURL("SystemUpdate.zip", "http://www.xbox.com/system-update-usb")
+        fw = getFileOrURL("SystemUpdate.zip",
+                          "http://www.xbox.com/system-update-usb")
         pirs = extractPirsFromZip(fw)
 
-        lang = ["English", "Japanese", "German", "French", "Spanish", "Italian",
-                "Korean", "Chinese", "Portuguese"]
+        lang = ["English", "Japanese", "German", "French", "Spanish",
+                "Italian", "Korean", "Chinese", "Portuguese"]
         sio = StringIO.StringIO(pirs)
         basename = "FFFE07DF00000001"
         sio.name = basename

--- a/src/fwfetcher.py
+++ b/src/fwfetcher.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python2
 
+from __future__ import print_function
+
 from urllib2 import Request, urlopen, URLError
 import hashlib
 import os
@@ -36,8 +38,8 @@ def check_size(fsize, minsize):
     """
 
     if fsize < minsize:
-        print "Input file too small: %i instead of at least %i bytes." % \
-            (fsize, minsize)
+        print("Input file too small: %i instead of at least %i bytes." % (
+            fsize, minsize))
     return fsize >= minsize
 
 ###############################################################################
@@ -51,7 +53,7 @@ def nice_open_file(filename):
     """
 
     if os.path.isfile(filename):
-        print filename, "already exists, overwrite? (y/n)",
+        print(filename, "already exists, overwrite? (y/n)", end=' ')
         answer = raw_input("")
         return len(answer) > 0 and answer[0] in ["Y", "y"]
     else:
@@ -69,7 +71,8 @@ def nice_open_dir(dirname):
     """
 
     if os.path.isdir(dirname):
-        print dirname, "already exists, ok to overwrite files in it? (y/n)",
+        print(dirname, "already exists, ok to overwrite files in it? (y/n)",
+              end=' ')
         answer = raw_input("")
         return len(answer) > 0 and answer[0] in ["Y", "y"]
     else:
@@ -116,7 +119,7 @@ def open_info_file(infile):
 
     txtname = os.path.basename(infile.name) + ".txt"
     if nice_open_file(txtname):
-        print "Writing information file", txtname
+        print("Writing information file", txtname)
         txtfile = open(txtname, "w")
         return txtfile
     else:
@@ -138,13 +141,13 @@ def dump_png(infile, pnglen, maxlen, pngid):
         outname = os.path.basename(infile.name) + "_" + pngid + ".png"
         if nice_open_file(outname):
             buf = infile.read(pnglen)
-            print "Writing PNG file", outname
+            print("Writing PNG file", outname)
             outfile = open(outname, "wb")
-            print >> outfile, buf,
+            print(buf, end=' ', file=outfile)
             outfile.close()
     else:
-        print "PNG image %s too large (%i instead of maximal %i bytes), " \
-            "file not written." % (pngid, pnglen, maxlen)
+        print("PNG image %s too large (%i instead of maximal %i bytes), "
+              "file not written." % (pngid, pnglen, maxlen))
 
 ###############################################################################
 
@@ -157,11 +160,11 @@ def dump_info(infile, txtfile, what):
               descriptions
     """
 
-    print >> txtfile, "\n", what, ":"
+    print("\n", what, ":", file=txtfile)
     for i in xrange(9):
         info = strip_blanks(infile.read(0x100))
         if len(info) > 0:
-            print >> txtfile, lang[i], ":", info
+            print(lang[i], ":", info, file=txtfile)
 
 ###############################################################################
 
@@ -284,29 +287,29 @@ def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
 
         nlen = namelen & ~0xC0
         if nlen < 1 or nlen > 40:
-            print "Filename length (%i) out of range, skipping file." % nlen
+            print("Filename length (%i) out of range, skipping file." % nlen)
             continue
         outname = outname[0:nlen]  # strip trailing 0x00 from filename
 
         if txtfile != None:
             if namelen & 0x80 == 0x80:
-                print >> txtfile, "Directory",
+                print("Directory", end=' ', file=txtfile)
             else:
-                print >> txtfile, "File",
-            print >> txtfile, "name:", outname
+                print("File", end=' ', file=txtfile)
+            print("name:", outname, file=txtfile)
             if namelen & 0x40 == 0x40:
-                print >> txtfile, "Bit 6 of namelen is set."
+                print("Bit 6 of namelen is set.", file=txtfile)
 
         if clustsize1 != clustsize2:
-            print "Cluster sizes don't match (%i != %i), skipping file." % \
-                (clustsize1, clustsize2)
+            print("Cluster sizes don't match (%i != %i), skipping file." % (
+                clustsize1, clustsize2))
             continue
         if startclust < 1 and namelen & 0x80 == 0:
-            print "Starting cluster must be 1 or greater, skipping file."
+            print("Starting cluster must be 1 or greater, skipping file.")
             continue
         if filelen > 0x1000 * clustsize1:
-            print "File length (%i) is greater than the size in clusters " \
-                "(%i), skipping file." % (filelen, clustsize1)
+            print("File length (%i) is greater than the size in clusters "
+                  "(%i), skipping file." % (filelen, clustsize1))
             continue
 
         if pathind != oldpathind:
@@ -324,7 +327,7 @@ def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
             # space between files is set to 0x00
             adstart = startclust * 0x1000 + start
             if txtfile != None:
-                print >> txtfile, "Starting: advertized", hex(adstart)
+                print("Starting: advertized", hex(adstart), file=txtfile)
 
             # block reading algorithm originally from wxPirs
             buf = ""
@@ -336,7 +339,7 @@ def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
                 adstart += 0x1000
                 filelen -= 0x1000
             outfile = open(outname, "wb")
-            print >> outfile, buf,
+            print(buf, end=' ', file=outfile)
             outfile.close()
 
         do_utime(outname, dati2, dati1)
@@ -364,47 +367,50 @@ def write_common_part(infile, txtfile, png2stop, start):
     (mentry_id, content_type) = struct.unpack(">LL", infile.read(8))
 
     if txtfile != None:
-        print >> txtfile, "\nMaster SHA1 hash :", \
-            check_sha1(mhash, mentry_id, infile, 0x0344, png2stop)
-        print >> txtfile, "\nContent type", hex(content_type), ":",
+        print("\nMaster SHA1 hash :",
+              check_sha1(mhash, mentry_id, infile, 0x0344, png2stop),
+              file=txtfile)
+        print("\nContent type", hex(content_type), ":", end=' ', file=txtfile)
         # content type list partially from V1kt0R
         # su20076000_00000000 has type 0x000b0000,
         # i.e. "Full game demo" & "Theme" ...
         if content_type == 0:
-            print >> txtfile, "(no type)"
+            print("(no type)", file=txtfile)
         elif content_type & 0x00000001:
-            print >> txtfile, "Game save"
+            print("Game save", file=txtfile)
         elif content_type & 0x00000002:
-            print >> txtfile, "Game add-on"
+            print("Game add-on", file=txtfile)
         elif content_type & 0x00030000:
-            print >> txtfile, "Theme"
+            print("Theme", file=txtfile)
         elif content_type & 0x00090000:
-            print >> txtfile, "Video clip"
+            print("Video clip", file=txtfile)
         elif content_type & 0x000C0000:
-            print >> txtfile, "Game trailer"
+            print("Game trailer", file=txtfile)
         elif content_type & 0x000D0000:
-            print >> txtfile, "XBox Live Arcade"
+            print("XBox Live Arcade", file=txtfile)
         elif content_type & 0x00010000:
-            print >> txtfile, "Gamer profile"
+            print("Gamer profile", file=txtfile)
         elif content_type & 0x00020000:
-            print >> txtfile, "Gamer picture"
+            print("Gamer picture", file=txtfile)
         elif content_type & 0x00040000:
-            print >> txtfile, "System update"
+            print("System update", file=txtfile)
         elif content_type & 0x00080000:
-            print >> txtfile, "Full game demo"
+            print("Full game demo", file=txtfile)
         else:
-            print >> txtfile, "(unknown)"
+            print("(unknown)", file=txtfile)
 
-        print >> txtfile, "\nDirectory data at (hex)", hex(start)
+        print("\nDirectory data at (hex)", hex(start), file=txtfile)
         infile.seek(0x410)
         dump_info(infile, txtfile, "Titles")
         dump_info(infile, txtfile, "Descriptions")
-        print >> txtfile, "\nPublisher:", strip_blanks(infile.read(0x80)), "\n"
-        print >> txtfile, "\nFilename:", strip_blanks(infile.read(0x80)), "\n"
+        print("\nPublisher:", strip_blanks(infile.read(0x80)), "\n",
+              file=txtfile)
+        print("\nFilename:", strip_blanks(infile.read(0x80)), "\n",
+              file=txtfile)
     infile.seek(0x1710)
     (val1, png1len, png2len) = struct.unpack(">HLL", infile.read(10))
     if txtfile != None:
-        print >> txtfile, "Value:", val1
+        print("Value:", val1, file=txtfile)
 
     if png1len > 0:
         dump_png(infile, png1len, 0x571A - 0x171A, "1")
@@ -424,7 +430,7 @@ def write_common_part(infile, txtfile, png2stop, start):
     outname = os.path.basename(infile.name) + ".dir"
     makedir = nice_open_dir(outname)
     if makedir:
-        print "Creating and filling content directory", outname
+        print("Creating and filling content directory", outname)
         do_mkdir(outname)
         os.chdir(outname)
     if png2stop == 0xB000 and start == 0xC000:
@@ -435,7 +441,7 @@ def write_common_part(infile, txtfile, png2stop, start):
 
     # table of SHA1 hashes of payload
     if txtfile != None:
-        print >> txtfile
+        print(file=txtfile)
         infile.seek(png2stop)
         buf = infile.read(start - png2stop)
         numempty = 0
@@ -443,20 +449,20 @@ def write_common_part(infile, txtfile, png2stop, start):
             entry = buf[i * 24: i * 24 + 24]
             if entry.count("\0") < 24:
                 if numempty > 0:
-                    print >> txtfile, "\nEmpty entries:", numempty
+                    print("\nEmpty entries:", numempty, file=txtfile)
                     numempty = 0
-                print >> txtfile, "Hash (hex):",
+                print("Hash (hex):", end=' ', file=txtfile)
                 for j in xrange(20):
-                    print >> txtfile, hex(ord(entry[j])),
+                    print(hex(ord(entry[j])), end=' ', file=txtfile)
                 (j, ) = struct.unpack(">L", entry[20:24])
-                print >> txtfile, "\nEntry id:", hex(j)
+                print("\nEntry id:", hex(j), file=txtfile)
             else:
                 numempty += 1
 
-        print >> txtfile, "\nTrailing data (hex):",
+        print("\nTrailing data (hex):", end=' ', file=txtfile)
         for i in buf[len(buf) - (len(buf) % 24):]:
-            print >> txtfile, hex(ord(i)),
-        print >> txtfile
+            print(hex(ord(i)), end=' ', file=txtfile)
+        print(file=txtfile)
 
         txtfile.close()
 
@@ -471,23 +477,23 @@ def handle_live_pirs(infile, fsize):
        @param fsize size of infile
     """
 
-    print "Handling LIVE/PIRS file."
+    print("Handling LIVE/PIRS file.")
 
     if not check_size(fsize, 0xD000):
         return
 
     txtfile = open_info_file(infile)
     if txtfile != None:
-        print >> txtfile, "Certificate (hex):",
+        print("Certificate (hex):", end=' ', file=txtfile)
         cert = infile.read(0x100)
         for i in cert:
-            print >> txtfile, hex(ord(i)),
+            print(hex(ord(i)), end=' ', file=txtfile)
 
-        print >> txtfile, "\n\nData (hex):",
+        print("\n\nData (hex):", end=' ', file=txtfile)
         data = infile.read(0x228)
         for i in data:
-            print >> txtfile, hex(ord(i)),
-        print >> txtfile
+            print(hex(ord(i)), end=' ', file=txtfile)
+        print(file=txtfile)
 
     # BEGIN wxPirs
     infile.seek(0xC032)  # originally 4 bytes at 0xC030
@@ -509,36 +515,38 @@ def getFileOrURL(filename, url):
     # contents.
     try:
         f = open(filename)
-        print "Found", filename, "cached on disk, using local copy"
+        print("Found", filename, "cached on disk, using local copy")
         retval = f.read()
         return retval
     except IOError, e:
         pass
-    print "Downloading", filename, "from", url
+    print("Downloading", filename, "from", url)
     req = Request(url)
     try:
         response = urlopen(req)
     except URLError, e:
         if hasattr(e, 'reason'):
-            print "Failed to reach download server.  Reason:", e.reason
+            print("Failed to reach download server.  Reason:", e.reason)
         elif hasattr(e, 'code'):
-            print "The server couldn't fulfill the request.  Error code:", e.code
-    print "Reading response..."
+            print("The server couldn't fulfill the request.  Error code:",
+                  e.code)
+    print("Reading response...")
     retval = response.read()
     # Save downloaded file to disk
     f = open(filename, "wb")
     f.write(retval)
     f.close()
-    print "done, saved to", filename
+    print("done, saved to", filename)
     return retval
 
 def extractPirsFromZip(systemupdate):
-    print "Extracting $SystemUpdate/FFFE07DF00000001 from system update file..."
+    print("Extracting $SystemUpdate/FFFE07DF00000001 from system update "
+          "file...")
     updatefile = StringIO.StringIO(systemupdate)
     z = zipfile.ZipFile(updatefile)
-    # print z.namelist()
+    # print(z.namelist())
     pirs = z.open("$SystemUpdate/FFFE07DF00000001").read()
-    print "done."
+    print("done.")
     return pirs
 
 if __name__ == "__main__":
@@ -559,10 +567,10 @@ if __name__ == "__main__":
         handle_live_pirs(sio, len(pirs) - 4)
 
         os.chdir(pwd)
-        print "Moving audios.bin to current folder"
+        print("Moving audios.bin to current folder")
         os.rename(os.path.join(basename + ".dir", "audios.bin"), target)
 
-        print "Cleaning up"
+        print("Cleaning up")
         os.unlink(basename + ".txt")
         for root, dirs, files in os.walk(basename + ".dir"):
             for name in files:
@@ -571,6 +579,6 @@ if __name__ == "__main__":
                 os.rmdir(os.path.join(root, name))
             os.rmdir(root)
         os.unlink("SystemUpdate.zip")
-        print "Done!"
+        print("Done!")
     else:
-        print "Already have audios.bin"
+        print("Already have audios.bin")

--- a/src/fwfetcher.py
+++ b/src/fwfetcher.py
@@ -154,9 +154,8 @@ def dump_png(infile, pnglen, maxlen, pngid):
         if nice_open_file(outname):
             buf = infile.read(pnglen)
             print("Writing PNG file", outname)
-            outfile = open(outname, "wb")
-            print(buf, end=' ', file=outfile)
-            outfile.close()
+            with open(outname, "wb") as outfile:
+                print(buf, end=' ', file=outfile)
     else:
         print("PNG image %s too large (%i instead of maximal %i bytes), "
               "file not written." % (pngid, pnglen, maxlen))
@@ -350,9 +349,8 @@ def fill_directory(infile, txtfile, contents, firstclust, makedir, start,
                 startclust += 1
                 adstart += 0x1000
                 filelen -= 0x1000
-            outfile = open(outname, "wb")
-            print(buf, end=' ', file=outfile)
-            outfile.close()
+            with open(outname, "wb") as outfile:
+                print(buf, end=' ', file=outfile)
 
         do_utime(outname, dati2, dati1)
 
@@ -526,9 +524,9 @@ def getFileOrURL(filename, url):
     # If so, return its contents.  If not, download it, save it, and return its
     # contents.
     try:
-        f = open(filename)
-        print("Found", filename, "cached on disk, using local copy")
-        retval = f.read()
+        with open(filename) as f:
+            print("Found", filename, "cached on disk, using local copy")
+            retval = f.read()
         return retval
     except IOError:
         pass
@@ -545,9 +543,8 @@ def getFileOrURL(filename, url):
     print("Reading response...")
     retval = response.read()
     # Save downloaded file to disk
-    f = open(filename, "wb")
-    f.write(retval)
-    f.close()
+    with open(filename, "wb") as f:
+        f.write(retval)
     print("done, saved to", filename)
     return retval
 
@@ -555,9 +552,9 @@ def extractPirsFromZip(systemupdate):
     print("Extracting $SystemUpdate/FFFE07DF00000001 from system update "
           "file...")
     updatefile = StringIO.StringIO(systemupdate)
-    z = zipfile.ZipFile(updatefile)
-    # print(z.namelist())
-    pirs = z.open("$SystemUpdate/FFFE07DF00000001").read()
+    with zipfile.ZipFile(updatefile) as z:
+        # print(z.namelist())
+        pirs = z.open("$SystemUpdate/FFFE07DF00000001").read()
     print("done.")
     return pirs
 

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -2,38 +2,71 @@
 # Python extension builder
 ######################################################################################
 
-include(FindPythonInterp)
-include(FindPythonLibs)
+macro(Python_BUILD_EXTENSION Python_BUILD_VERSION)
 
+set(Python_ADDITIONAL_VERSIONS ${Python_BUILD_VERSION})
+find_package(PythonInterp)
+set(PYTHON${Python_BUILD_VERSION}INTERP_FOUND    ${PYTHONINTERP_FOUND})
+set(PYTHON${Python_BUILD_VERSION}_EXECUTABLE     ${PYTHON_EXECUTABLE})
+set(PYTHON${Python_BUILD_VERSION}_VERSION_STRING ${PYTHON_VERSION_STRING})
+set(PYTHON${Python_BUILD_VERSION}_VERSION_MAJOR  ${PYTHON_VERSION_MAJOR})
+set(PYTHON${Python_BUILD_VERSION}_VERSION_MINOR  ${PYTHON_VERSION_MINOR})
+set(PYTHON${Python_BUILD_VERSION}_VERSION_PATCH  ${PYTHON_VERSION_PATCH})
+find_package(PythonLibs)
+set(PYTHON${Python_BUILD_VERSION}LIBS_FOUND          ${PYTHONLIBS_FOUND})
+set(PYTHON${Python_BUILD_VERSION}LIBS_VERSION_STRING ${PYTHONLIBS_VERSION_STRING})
+set(PYTHON${Python_BUILD_VERSION}_DEBUG_LIBRARIES    ${PYTHON_DEBUG_LIBRARIES})
+set(PYTHON${Python_BUILD_VERSION}_INCLUDE_PATH       ${PYTHON_INCLUDE_PATH})
+set(PYTHON${Python_BUILD_VERSION}_INCLUDE_DIRS       ${PYTHON_INCLUDE_DIRS})
+set(PYTHON${Python_BUILD_VERSION}_LIBRARIES          ${PYTHON_LIBRARIES})
 find_program(CYTHON_EXECUTABLE cython)
 
 # Figure out installation path
 execute_process(COMMAND
-  ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}'))"
-  OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+  ${PYTHON${Python_BUILD_VERSION}_EXECUTABLE}
+    -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}'))"
+  OUTPUT_VARIABLE PYTHON${Python_BUILD_VERSION}_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 # Figure out numpy include path
 execute_process(COMMAND
-  ${PYTHON_EXECUTABLE} -c "import numpy; print(numpy.get_include())"
-  OUTPUT_VARIABLE NUMPY_INCLUDE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+  ${PYTHON${Python_BUILD_VERSION}_EXECUTABLE}
+    -c "import numpy; print(numpy.get_include())"
+  OUTPUT_VARIABLE PYTHON${Python_BUILD_VERSION}_NUMPY_INCLUDE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 # How to Cython the .pyx file
-add_custom_command(OUTPUT freenect.c
-  COMMAND ${CYTHON_EXECUTABLE} -o freenect.c "${CMAKE_CURRENT_SOURCE_DIR}/freenect.pyx")
-list(APPEND ADDITIONAL_MAKE_CLEAN_FILES freenect.c)
+add_custom_command(OUTPUT freenect${Python_BUILD_VERSION}.c
+  COMMAND
+    ${CYTHON_EXECUTABLE}
+      -${Python_BUILD_VERSION}
+      -o freenect${Python_BUILD_VERSION}.c
+      "${CMAKE_CURRENT_SOURCE_DIR}/freenect.pyx")
+list(APPEND ADDITIONAL_MAKE_CLEAN_FILES freenect${Python_BUILD_VERSION}.c)
 
 # Compile the extension
-add_library(cython_freenect MODULE freenect.c)
-set_target_properties(cython_freenect PROPERTIES
+add_library(cython${Python_BUILD_VERSION}_freenect MODULE freenect${Python_BUILD_VERSION}.c)
+set_target_properties(cython${Python_BUILD_VERSION}_freenect PROPERTIES
   PREFIX ""
   OUTPUT_NAME "freenect"
-  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(cython_freenect freenect_sync ${PYTHON_LIBRARIES})
-include_directories(${PYTHON_INCLUDE_PATH} ../c_sync/ ${NUMPY_INCLUDE_PATH})
+  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python${Python_BUILD_VERSION})
+target_link_libraries(cython${Python_BUILD_VERSION}_freenect
+  freenect_sync
+  ${PYTHON${Python_BUILD_VERSION}_LIBRARIES})
+target_include_directories(cython${Python_BUILD_VERSION}_freenect PRIVATE
+  ${PYTHON${Python_BUILD_VERSION}_INCLUDE_PATH}
+  ../c_sync/
+  ${PYTHON${Python_BUILD_VERSION}_NUMPY_INCLUDE_PATH})
 
 # Install the extension
-install(TARGETS cython_freenect
-  DESTINATION ${PYTHON_SITE_PACKAGES})
+install(TARGETS cython${Python_BUILD_VERSION}_freenect
+  DESTINATION ${PYTHON${Python_BUILD_VERSION}_SITE_PACKAGES})
 
 # TODO: decide on what to do with demo_ scripts and were to install
 #       them
+endmacro(Python_BUILD_EXTENSION)
+
+if (BUILD_PYTHON2)
+  Python_BUILD_EXTENSION(2)
+endif(BUILD_PYTHON2)
+if (BUILD_PYTHON3)
+  Python_BUILD_EXTENSION(3)
+endif(BUILD_PYTHON3)

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -9,12 +9,12 @@ find_program(CYTHON_EXECUTABLE cython)
 
 # Figure out installation path
 execute_process(COMMAND
-  ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}')"
+  ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}'))"
   OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 # Figure out numpy include path
 execute_process(COMMAND
-  ${PYTHON_EXECUTABLE} -c "import numpy; print numpy.get_include()"
+  ${PYTHON_EXECUTABLE} -c "import numpy; print(numpy.get_include())"
   OUTPUT_VARIABLE NUMPY_INCLUDE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 # How to Cython the .pyx file

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -4,6 +4,22 @@
 
 macro(Python_BUILD_EXTENSION Python_BUILD_VERSION)
 
+# Unfortunately, we can't use the cache because it treats 2 and 3 the same, so
+# we wouldn't be able to compile against both.
+foreach(_python_var
+    PYTHONINTERP_FOUND PYTHON_EXECUTABLE PYTHON_VERSION_STRING
+    PYTHON_VERSION_MAJOR PYTHON_VERSION_MINOR PYTHON_VERSION_PATCH)
+  unset(${_python_var})
+  unset(${_python_var} CACHE)
+endforeach(_python_var)
+foreach(_python_var
+    PYTHONLIBS_FOUND PYTHONLIBS_VERSION_STRING PYTHON_DEBUG_LIBRARIES
+    PYTHON_INCLUDE_DIR PYTHON_INCLUDE_DIRS PYTHON_INCLUDE_PATH PYTHON_LIBRARIES
+    PYTHON_LIBRARY PYTHON_LIBRARY_DEBUG)
+  unset(${_python_var})
+  unset(${_python_var} CACHE)
+endforeach(_python_var)
+
 set(Python_ADDITIONAL_VERSIONS ${Python_BUILD_VERSION})
 find_package(PythonInterp)
 set(PYTHON${Python_BUILD_VERSION}INTERP_FOUND    ${PYTHONINTERP_FOUND})
@@ -20,6 +36,16 @@ set(PYTHON${Python_BUILD_VERSION}_INCLUDE_PATH       ${PYTHON_INCLUDE_PATH})
 set(PYTHON${Python_BUILD_VERSION}_INCLUDE_DIRS       ${PYTHON_INCLUDE_DIRS})
 set(PYTHON${Python_BUILD_VERSION}_LIBRARIES          ${PYTHON_LIBRARIES})
 find_program(CYTHON_EXECUTABLE cython)
+
+if(NOT ${PYTHON${Python_BUILD_VERSION}_VERSION_MAJOR} EQUAL ${Python_BUILD_VERSION})
+  message(FATAL_ERROR "Unable to find Python ${Python_BUILD_VERSION} interpreter.")
+endif()
+if(NOT ${PYTHON${Python_BUILD_VERSION}_VERSION_STRING} EQUAL ${PYTHON${Python_BUILD_VERSION}LIBS_VERSION_STRING})
+  message(FATAL_ERROR
+          "Unable to find consistent Python ${Python_BUILD_VERSION} libraries. "
+          "Python interpreter is ${PYTHON${Python_BUILD_VERSION}_VERSION_STRING}, "
+          "but libraries are ${PYTHON${Python_BUILD_VERSION}LIBS_VERSION_STRING}.")
+endif()
 
 # Figure out installation path
 execute_process(COMMAND


### PR DESCRIPTION
There have been some on-and-off changes to make it work, but nothing that covered the entire build. This PR:
 * Makes `fwfetcher.py` Python 3 compatible (thus reverts #370)
 * Adds a second wrapper build for Python 3
   * The `BUILD_PYTHON` CMake option will now build both 2 and 3.
   * `BUILD_PYTHON2` will build only the Python 2 extension.
   * `BUILD_PYTHON3` will build only the Python 3 extension.

I have tested that it compiles and imports against 2.7, 3.3, 3.4, and 3.5 and in various combinations of the `BUILD_PYTHON*` options. Unfortunately, I cannot test all the examples because they require newer OpenCV for Python 3 support (maybe #450 will fix that.) Also, I don't actually own a Kinect...