### PR TITLE
BF: FN_INTERNAL for fnusb_claim_camera to not leak into public API

### DIFF
--- a/src/usb_libusb10.c
+++ b/src/usb_libusb10.c
@@ -252,7 +252,7 @@ FN_INTERNAL int fnusb_process_events_timeout(fnusb_ctx *ctx, struct timeval* tim
 	return libusb_handle_events_timeout(ctx->ctx, timeout);
 }
 
-int fnusb_claim_camera(freenect_device* dev)
+FN_INTERNAL int fnusb_claim_camera(freenect_device* dev)
 {
 	freenect_context *ctx = dev->parent;
 


### PR DESCRIPTION
I guess it just managed to sneak in within dcb292966071eee7c353662264dc8358e4a58cc2 