### PR TITLE
ssize_t type should be different for x86 and x64

### DIFF
--- a/platform/windows/unistd.h
+++ b/platform/windows/unistd.h
@@ -34,7 +34,11 @@
 // MSVC does not define this.
 #ifndef _SSIZE_T_DEFINED
 #define _SSIZE_T_DEFINED
-typedef long ssize_t;
+#ifdef _WIN64
+	typedef __int64 ssize_t;
+#else
+	typedef int ssize_t;
+#endif
 #endif // _SSIZE_T_DEFINED
 
 


### PR DESCRIPTION
VS2015 won't compile in x64 bc of conflicting types for ssize_t with libusb; as explained here: https://github.com/OpenKinect/libfreenect/issues/476