### PR TITLE
Allow micview to exit cleanly on Linux

### DIFF
--- a/examples/micview.c
+++ b/examples/micview.c
@@ -40,6 +40,8 @@
 pthread_t freenect_thread;
 volatile int die = 0;
 
+int window;
+
 static freenect_context* f_ctx;
 static freenect_device* f_dev;
 
@@ -149,7 +151,8 @@ void Reshape(int w, int h) {
 void Keyboard(unsigned char key, int x, int y) {
 	if(key == 'q') {
 		die = 1;
-		pthread_exit(NULL);
+		pthread_join(freenect_thread, NULL);
+		glutDestroyWindow(window);
 	}
 	if(key == 32) {
 		paused = !paused;
@@ -205,7 +208,7 @@ int main(int argc, char** argv) {
 	glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGBA | GLUT_ALPHA );
 	glutInitWindowSize(800, 600);
 	glutInitWindowPosition(0, 0);
-	glutCreateWindow("Microphones");
+	window = glutCreateWindow("Microphones");
 	glClearColor(0.0, 0.0, 0.0, 0.0);
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);


### PR DESCRIPTION
This change fixes a bug where micview would hang when the user presses 'q' to
exit, and you'd have to kill -9 the process to make the window go away.

On Linux, with at least the radeon graphics driver, glutCreateWindow appears to
spawn several child threads for shaders, a disk cache, and something else:

si_shader:0
si_shader:1
si_shader:2
si_shader:3
disk_cache:0
radeon_cs:0

These threads appear to keep the process as a whole from exiting when
pthread_exit() is called.  The solution is to call glutDestroyWindow(), which
will cause glutMainLoop() to return, which causes main() to return cleanly.