### PR TITLE
[compile] fix non-c99 regression in for() loop

### DIFF
--- a/fakenect/fakenect.c
+++ b/fakenect/fakenect.c
@@ -529,7 +529,8 @@ int freenect_init(freenect_context **ctx, freenect_usb_context *usb_ctx)
 	if (var) {
 		int len = strlen(var);
 		char tmp[len + 1];
-		for (int i = 0; i < len; i++)
+		int i;
+		for (i = 0; i < len; i++)
 			tmp[i] = tolower(var[i]);
 		tmp[len] = '\0';
 		if (strcmp(tmp, "0") == 0 ||


### PR DESCRIPTION
A recent commit 774570fe520426b4caf86c07a6f5b5b7d65ef905 introduced a compilation regression when compiling `libfreenect` and `fakenect` specifically on EL6 platforms, where it previously did not exist due to the introduced `for(int i ..)` declaration, which is also inconsistent with the rest of the code:

```
...
[ 83%] Building C object fakenect/CMakeFiles/fakenect.dir/fakenect.c.o
.../OpenISS/libfreenect/fakenect/fakenect.c: In function ‘freenect_init’:
.../OpenISS/libfreenect/fakenect/fakenect.c:532: error: ‘for’ loop initial declarations are only allowed in C99 mode
.../OpenISS/libfreenect/fakenect/fakenect.c:532: note: use option -std=c99 or -std=gnu99 to compile your code
make[2]: *** [fakenect/CMakeFiles/fakenect.dir/fakenect.c.o] Error 1
make[1]: *** [fakenect/CMakeFiles/fakenect.dir/all] Error 2
make: *** [all] Error 2
```
So this simple one-liner makes it all happy again.