### PR TITLE
fix for issue #540, proper initialization of member variable

### DIFF
--- a/OpenNI2-FreenectDriver/src/VideoStream.hpp
+++ b/OpenNI2-FreenectDriver/src/VideoStream.hpp
@@ -28,6 +28,7 @@ namespace FreenectDriver
       frame_id(1),
       prev_timestamp(0),
       device(device),
+      running(false),
       mirroring(false)
       {
         // joy of structs


### PR DESCRIPTION
Proper initialization added to `VideoStream` constuctor. 