### PR TITLE
Add a method to get a serial number from a device

### DIFF
--- a/examples/camtest.c
+++ b/examples/camtest.c
@@ -26,6 +26,7 @@
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "libfreenect.h"
 
@@ -90,6 +91,12 @@ int main(int argc, char** argv)
 	{
 		freenect_shutdown(fn_ctx);
 		return ret;
+	}
+
+	{
+		char* serial = freenect_get_device_serial(fn_dev);
+		if (serial) printf("Found device with serial %s\n", serial);
+		free(serial);
 	}
 
 	// Set depth and video modes.

--- a/include/libfreenect.h
+++ b/include/libfreenect.h
@@ -356,6 +356,15 @@ FREENECTAPI int freenect_open_device(freenect_context *ctx, freenect_device **de
 FREENECTAPI int freenect_open_device_by_camera_serial(freenect_context *ctx, freenect_device **dev, const char* camera_serial);
 
 /**
+ * Gets a serial number for the device.
+ * The caller must free() the serial after use.
+ *
+ * @param dev
+ * @return an appropriate serial number, or NULL if none was found.
+ */
+FREENECTAPI char* freenect_get_device_serial(freenect_device* dev);
+
+/**
  * Closes a device that is currently open
  *
  * @param dev Device to close

--- a/src/core.c
+++ b/src/core.c
@@ -169,7 +169,7 @@ FREENECTAPI int freenect_open_device(freenect_context *ctx, freenect_device **de
 	*dev = pdev;
 
 	// Do device-specific initialization
-	if (pdev->usb_cam.dev) {
+	if (pdev->usb_cam.dev_handle) {
 		if (freenect_camera_init(pdev) < 0) {
 			return -1;
 		}
@@ -207,7 +207,7 @@ FREENECTAPI int freenect_close_device(freenect_device *dev)
 	freenect_context *ctx = dev->parent;
 	int res;
 
-	if (dev->usb_cam.dev) {
+	if (dev->usb_cam.dev_handle) {
 		freenect_camera_teardown(dev);
 	}
 

--- a/src/core.c
+++ b/src/core.c
@@ -202,6 +202,19 @@ FREENECTAPI int freenect_open_device_by_camera_serial(freenect_context *ctx, fre
 	return -1;
 }
 
+FREENECTAPI char* freenect_get_device_serial(freenect_device* dev)
+{
+	if (dev == NULL) return NULL;
+
+	char* camera_serial = fnusb_get_serial(&dev->usb_cam);
+	if (camera_serial) return camera_serial;
+
+	char* audio_serial = fnusb_get_serial(&dev->usb_audio);
+	if (audio_serial) return audio_serial;
+
+	return NULL;
+}
+
 FREENECTAPI int freenect_close_device(freenect_device *dev)
 {
 	freenect_context *ctx = dev->parent;

--- a/src/tilt.c
+++ b/src/tilt.c
@@ -101,7 +101,7 @@ int update_tilt_state_alt(freenect_device *dev)
 {
 	freenect_context *ctx = dev->parent;
 
-	if (dev->usb_audio.dev == NULL)
+	if (dev->usb_audio.dev_handle == NULL)
 	{
 		FN_WARNING("Motor control failed: audio device missing");
 		return -1;
@@ -118,13 +118,13 @@ int update_tilt_state_alt(freenect_device *dev)
 	unsigned char buffer[256];
 	memcpy(buffer, &cmd, 16);
     
-	res = libusb_bulk_transfer(dev->usb_audio.dev, 0x01, buffer, 16, &transferred, 250);
+	res = libusb_bulk_transfer(dev->usb_audio.dev_handle, 0x01, buffer, 16, &transferred, 250);
 	if (res != 0)
 	{
 		return res;
 	}
     
-	res = libusb_bulk_transfer(dev->usb_audio.dev, 0x81, buffer, 256, &transferred, 250); // 104 bytes
+	res = libusb_bulk_transfer(dev->usb_audio.dev_handle, 0x81, buffer, 256, &transferred, 250); // 104 bytes
 	if (res != 0)
 	{
 		return res;
@@ -149,7 +149,7 @@ int update_tilt_state_alt(freenect_device *dev)
 
 	// Reply: skip four uint32_t, then you have three int32_t that give you acceleration in that direction, it seems.
 	// Units still to be worked out.
-	return get_reply(dev->usb_audio.dev, ctx);
+	return get_reply(dev->usb_audio.dev_handle, ctx);
 }
 
 int freenect_update_tilt_state(freenect_device *dev)
@@ -195,7 +195,7 @@ int freenect_set_tilt_degs_alt(freenect_device *dev, int tilt_degrees)
 		return -1;
 	}
 
-	if (dev->usb_audio.dev == NULL)
+	if (dev->usb_audio.dev_handle == NULL)
 	{
 		FN_WARNING("Motor control failed: audio device missing");
 		return -1;
@@ -212,13 +212,13 @@ int freenect_set_tilt_degs_alt(freenect_device *dev, int tilt_degrees)
 	unsigned char buffer[20];
 	memcpy(buffer, &cmd, 20);
 
-	res = libusb_bulk_transfer(dev->usb_audio.dev, 0x01, buffer, 20, &transferred, 250);
+	res = libusb_bulk_transfer(dev->usb_audio.dev_handle, 0x01, buffer, 20, &transferred, 250);
 	if (res != 0) {
 		FN_ERROR("freenect_set_tilt_alt(): libusb_bulk_transfer failed: %s (transferred = %d)\n", libusb_error_name(res), transferred);
 		return res;
 	}
     
-	return get_reply(dev->usb_audio.dev, ctx);
+	return get_reply(dev->usb_audio.dev_handle, ctx);
 }
 
 int freenect_set_tilt_degs(freenect_device *dev, double angle)
@@ -291,13 +291,13 @@ int freenect_set_led_alt(freenect_device *dev, freenect_led_options state)
 {
 	freenect_context *ctx = dev->parent;
 
-	if (dev->usb_audio.dev == NULL)
+	if (dev->usb_audio.dev_handle == NULL)
 	{
 		FN_WARNING("Motor control failed: audio device missing");
 		return -1;
 	}
 
-	return fnusb_set_led_alt(dev->usb_audio.dev, ctx, state);
+	return fnusb_set_led_alt(dev->usb_audio.dev_handle, ctx, state);
 }
 
 int freenect_set_led(freenect_device *dev, freenect_led_options option)

--- a/src/usb_libusb10.c
+++ b/src/usb_libusb10.c
@@ -393,6 +393,18 @@ FN_INTERNAL int fnusb_keep_alive_led(freenect_context* ctx, libusb_device* audio
 	return res;
 }
 
+FN_INTERNAL void fnusb_reset_subdevice(fnusb_dev* dev, freenect_device* parent)
+{
+	if (dev->dev_handle) {
+		libusb_release_interface(dev->dev_handle, 0);
+		libusb_attach_kernel_driver(dev->dev_handle, 0);
+		libusb_close(dev->dev_handle);
+		dev->dev_handle = NULL;
+	}
+
+	dev->parent = parent;
+}
+
 FN_INTERNAL int fnusb_open_subdevices(freenect_device *dev, int index)
 {
 	freenect_context *ctx = dev->parent;
@@ -400,12 +412,9 @@ FN_INTERNAL int fnusb_open_subdevices(freenect_device *dev, int index)
 	dev->device_does_motor_control_with_audio = 0;
 	dev->motor_control_with_audio_enabled = 0;
     
-	dev->usb_cam.parent = dev;
-	dev->usb_cam.dev_handle = NULL;
-	dev->usb_motor.parent = dev;
-	dev->usb_motor.dev_handle = NULL;
-	dev->usb_audio.parent = dev;
-	dev->usb_audio.dev_handle = NULL;
+	fnusb_reset_subdevice(&dev->usb_cam, dev);
+	fnusb_reset_subdevice(&dev->usb_motor, dev);
+	fnusb_reset_subdevice(&dev->usb_audio, dev);
 
 	libusb_device **devs; // pointer to pointer of device, used to retrieve a list of devices
 	ssize_t count = libusb_get_device_list (dev->parent->usb.ctx, &devs); //get the list of devices
@@ -713,24 +722,9 @@ finally:
 
 FN_INTERNAL int fnusb_close_subdevices(freenect_device *dev)
 {
-	if (dev->usb_cam.dev_handle) {
-		libusb_release_interface(dev->usb_cam.dev_handle, 0);
-#ifndef _WIN32
-		libusb_attach_kernel_driver(dev->usb_cam.dev_handle, 0);
-#endif
-		libusb_close(dev->usb_cam.dev_handle);
-		dev->usb_cam.dev_handle = NULL;
-	}
-	if (dev->usb_motor.dev_handle) {
-		libusb_release_interface(dev->usb_motor.dev_handle, 0);
-		libusb_close(dev->usb_motor.dev_handle);
-		dev->usb_motor.dev_handle = NULL;
-	}
-	if (dev->usb_audio.dev_handle) {
-		libusb_release_interface(dev->usb_audio.dev_handle, 0);
-		libusb_close(dev->usb_audio.dev_handle);
-		dev->usb_audio.dev_handle = NULL;
-	}
+	fnusb_reset_subdevice(&dev->usb_cam, dev);
+	fnusb_reset_subdevice(&dev->usb_motor, dev);
+	fnusb_reset_subdevice(&dev->usb_audio, dev);
 	return 0;
 }
 

--- a/src/usb_libusb10.h
+++ b/src/usb_libusb10.h
@@ -56,8 +56,9 @@ typedef struct {
 
 typedef struct {
 	freenect_device *parent; //so we can go up from the libusb userdata
+	libusb_device *dev;
 	libusb_device_handle *dev_handle;
-	int device_dead; // set to 1 when the underlying libusb_device_handle vanishes (ie, Kinect was unplugged)
+	short device_dead; // set to 1 when the underlying libusb_device_handle vanishes (ie, Kinect was unplugged)
 	int VID;
 	int PID;
 } fnusb_dev;

--- a/src/usb_libusb10.h
+++ b/src/usb_libusb10.h
@@ -76,6 +76,7 @@ typedef struct {
 } fnusb_isoc_stream;
 
 int fnusb_num_devices(freenect_context *ctx);
+char* fnusb_get_serial(fnusb_dev* dev);
 int fnusb_list_device_attributes(freenect_context *ctx, struct freenect_device_attributes** attribute_list);
 
 int fnusb_init(fnusb_ctx *ctx, freenect_usb_context *usb_ctx);

--- a/src/usb_libusb10.h
+++ b/src/usb_libusb10.h
@@ -56,7 +56,7 @@ typedef struct {
 
 typedef struct {
 	freenect_device *parent; //so we can go up from the libusb userdata
-	libusb_device_handle *dev;
+	libusb_device_handle *dev_handle;
 	int device_dead; // set to 1 when the underlying libusb_device_handle vanishes (ie, Kinect was unplugged)
 	int VID;
 	int PID;


### PR DESCRIPTION
```
/**
 * Gets a serial number for the device.
 * The caller must free() the serial after use.
 *
 * @param dev
 * @return an appropriate serial number, or NULL if none was found.
 */
FREENECTAPI char* freenect_get_device_serial(freenect_device* dev);
```