### PR TITLE
Fix Windows Compiler error C2011

### DIFF
--- a/wrappers/c_sync/libfreenect_sync.c
+++ b/wrappers/c_sync/libfreenect_sync.c
@@ -24,6 +24,9 @@
  * either License.
  */
 #include <stdio.h>
+#ifdef _MSC_VER
+#define HAVE_STRUCT_TIMESPEC
+#endif
 #include <pthread.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
Quick fix to compile with Visual Studio.

Fixes #561 