### PR TITLE
build(wrappers/python): improve python detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Notice: If you have the newer Kinect v2 (XBox One), use [OpenKinect/libfreenect2
 To build libfreenect, you'll need
 
 - [libusb](http://libusb.info) >= 1.0.18 (Windows needs >= 1.0.22)
-- [CMake](http://cmake.org) >= 3.8.2
+- [CMake](http://cmake.org) >= 3.12.4
 - [python](http://python.org) >= 2.7 or >= 3.3 (only if BUILD_PYTHON=ON or BUILD_PYTHON2=ON or BUILD_PYTHON3=ON or BUILD_REDIST_PACKAGE=OFF)
 
 For the examples, you'll need

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -2,62 +2,34 @@
 # Python extension builder
 ######################################################################################
 
+cmake_minimum_required(VERSION 3.12.4)
+
+set(Python2_EXACTVERSION CACHE STRING "exact version of python2")
+set(Python3_EXACTVERSION CACHE STRING "exact version of python3")
+
 macro(Python_BUILD_EXTENSION Python_BUILD_VERSION)
 
-# Unfortunately, we can't use the cache because it treats 2 and 3 the same, so
-# we wouldn't be able to compile against both.
-foreach(_python_var
-    PYTHONINTERP_FOUND PYTHON_EXECUTABLE PYTHON_VERSION_STRING
-    PYTHON_VERSION_MAJOR PYTHON_VERSION_MINOR PYTHON_VERSION_PATCH)
-  unset(${_python_var})
-  unset(${_python_var} CACHE)
-endforeach(_python_var)
-foreach(_python_var
-    PYTHONLIBS_FOUND PYTHONLIBS_VERSION_STRING PYTHON_DEBUG_LIBRARIES
-    PYTHON_INCLUDE_DIR PYTHON_INCLUDE_DIRS PYTHON_INCLUDE_PATH PYTHON_LIBRARIES
-    PYTHON_LIBRARY PYTHON_LIBRARY_DEBUG)
-  unset(${_python_var})
-  unset(${_python_var} CACHE)
-endforeach(_python_var)
+if(NOT ${Python${Python_BUILD_VERSION}_EXACTVERSION} STREQUAL "")
+  find_package(Python${Python_BUILD_VERSION} ${Python${Python_BUILD_VERSION}_EXACTVERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
+else()
+  find_package(Python${Python_BUILD_VERSION} REQUIRED COMPONENTS Interpreter Development)
+endif()
 
-set(Python_ADDITIONAL_VERSIONS ${Python_BUILD_VERSION})
-find_package(PythonInterp)
-set(PYTHON${Python_BUILD_VERSION}INTERP_FOUND    ${PYTHONINTERP_FOUND})
-set(PYTHON${Python_BUILD_VERSION}_EXECUTABLE     ${PYTHON_EXECUTABLE})
-set(PYTHON${Python_BUILD_VERSION}_VERSION_STRING ${PYTHON_VERSION_STRING})
-set(PYTHON${Python_BUILD_VERSION}_VERSION_MAJOR  ${PYTHON_VERSION_MAJOR})
-set(PYTHON${Python_BUILD_VERSION}_VERSION_MINOR  ${PYTHON_VERSION_MINOR})
-set(PYTHON${Python_BUILD_VERSION}_VERSION_PATCH  ${PYTHON_VERSION_PATCH})
-find_package(PythonLibs)
-set(PYTHON${Python_BUILD_VERSION}LIBS_FOUND          ${PYTHONLIBS_FOUND})
-set(PYTHON${Python_BUILD_VERSION}LIBS_VERSION_STRING ${PYTHONLIBS_VERSION_STRING})
-set(PYTHON${Python_BUILD_VERSION}_DEBUG_LIBRARIES    ${PYTHON_DEBUG_LIBRARIES})
-set(PYTHON${Python_BUILD_VERSION}_INCLUDE_PATH       ${PYTHON_INCLUDE_PATH})
-set(PYTHON${Python_BUILD_VERSION}_INCLUDE_DIRS       ${PYTHON_INCLUDE_DIRS})
-set(PYTHON${Python_BUILD_VERSION}_LIBRARIES          ${PYTHON_LIBRARIES})
 find_program(CYTHON_EXECUTABLE cython)
 
-if(NOT ${PYTHON${Python_BUILD_VERSION}_VERSION_MAJOR} EQUAL ${Python_BUILD_VERSION})
-  message(FATAL_ERROR "Unable to find Python ${Python_BUILD_VERSION} interpreter.")
-endif()
-if(NOT ${PYTHON${Python_BUILD_VERSION}_VERSION_STRING} EQUAL ${PYTHON${Python_BUILD_VERSION}LIBS_VERSION_STRING})
-  message(FATAL_ERROR
-          "Unable to find consistent Python ${Python_BUILD_VERSION} libraries. "
-          "Python interpreter is ${PYTHON${Python_BUILD_VERSION}_VERSION_STRING}, "
-          "but libraries are ${PYTHON${Python_BUILD_VERSION}LIBS_VERSION_STRING}.")
-endif()
-
 # Figure out installation path
+# CMake populates this var automatically but we need to specify prefix
 execute_process(COMMAND
-  ${PYTHON${Python_BUILD_VERSION}_EXECUTABLE}
-    -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}'))"
-  OUTPUT_VARIABLE PYTHON${Python_BUILD_VERSION}_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+  ${Python${Python_BUILD_VERSION}_EXECUTABLE}
+    -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=False, standard_lib=False, prefix='${CMAKE_INSTALL_PREFIX}'))"
+  OUTPUT_VARIABLE Python${Python_BUILD_VERSION}_SITELIB OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 # Figure out numpy include path
+# todo: CMake >= 3.14 populates this var automatically when using COMPONENTS NumPy
 execute_process(COMMAND
-  ${PYTHON${Python_BUILD_VERSION}_EXECUTABLE}
+  ${Python${Python_BUILD_VERSION}_EXECUTABLE}
     -c "import numpy; print(numpy.get_include())"
-  OUTPUT_VARIABLE PYTHON${Python_BUILD_VERSION}_NUMPY_INCLUDE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+  OUTPUT_VARIABLE Python${Python_BUILD_VERSION}_NumPy_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 # How to Cython the .pyx file
 add_custom_command(OUTPUT freenect${Python_BUILD_VERSION}.c
@@ -76,15 +48,15 @@ set_target_properties(cython${Python_BUILD_VERSION}_freenect PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python${Python_BUILD_VERSION})
 target_link_libraries(cython${Python_BUILD_VERSION}_freenect
   freenect_sync
-  ${PYTHON${Python_BUILD_VERSION}_LIBRARIES})
+  ${Python${Python_BUILD_VERSION}_LIBRARIES})
 target_include_directories(cython${Python_BUILD_VERSION}_freenect PRIVATE
-  ${PYTHON${Python_BUILD_VERSION}_INCLUDE_PATH}
+  ${Python${Python_BUILD_VERSION}_INCLUDE_DIRS}
   ../c_sync/
-  ${PYTHON${Python_BUILD_VERSION}_NUMPY_INCLUDE_PATH})
+  ${Python${Python_BUILD_VERSION}_NumPy_INCLUDE_DIRS})
 
 # Install the extension
 install(TARGETS cython${Python_BUILD_VERSION}_freenect
-  DESTINATION ${PYTHON${Python_BUILD_VERSION}_SITE_PACKAGES})
+  DESTINATION ${Python${Python_BUILD_VERSION}_SITELIB})
 
 # TODO: decide on what to do with demo_ scripts and were to install
 #       them


### PR DESCRIPTION
This PR improves detection of the Python interpreter and libraries via new CMake features like [`FindPython3`](https://cmake.org/cmake/help/v3.12/module/FindPython3.html).  There is now also the ability to specify the exact Python version like

    cmake .. -DBUILD_PYTHON3=ON -DPython3_EXACTVERSION="3.6.9"

which is useful on Gentoo where numpy is not yet available for python3.7.