### PR TITLE
Cv headers soname

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set (PROJECT_VER_PATCH 1)
 set (PROJECT_VER
   "${PROJECT_VER_MAJOR}.${PROJECT_VER_MINOR}.${PROJECT_VER_PATCH}")
 set (PROJECT_APIVER
-  "${PROJECT_VER_MAJOR}.${PROJECT_VER_MINOR}")
+  "${PROJECT_VER_MAJOR}")
 
 OPTION(BUILD_REDIST_PACKAGE "Build libfreenect in a legally-redistributable manner (only affects audio)" ON)
 OPTION(BUILD_EXAMPLES "Build example programs" ON)

--- a/wrappers/opencv/cvdemo.cpp
+++ b/wrappers/opencv/cvdemo.cpp
@@ -1,5 +1,4 @@
-#include <opencv/cv.h>
-#include <opencv/highgui.h>
+#include <opencv2/highgui/highgui_c.h>
 #include <stdio.h>
 #include "libfreenect_cv.h"
 

--- a/wrappers/opencv/libfreenect_cv.h
+++ b/wrappers/opencv/libfreenect_cv.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv/cv.h>
+#include <opencv2/core/core_c.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Here are two patches used by the fedora package.

Fix opencv headers compatible with opencv2+ including OpenCV4 that has dropped support for opencv/cv.h

There is also an issue with the SONAME that integrate the micro version whereas the ABI is compatible with the previous libfreenect 0.5.0. So keep using libfreenect.so.0 instead.