### PR TITLE
fix: move callbacks after vid/pid query

### DIFF
--- a/OpenNI2-FreenectDriver/src/DeviceDriver.cpp
+++ b/OpenNI2-FreenectDriver/src/DeviceDriver.cpp
@@ -252,9 +252,7 @@ namespace FreenectDriver
         strncpy(info.uri, uri.c_str(), ONI_MAX_STR);
         strncpy(info.vendor, "Microsoft", ONI_MAX_STR);
         strncpy(info.name, "Kinect", ONI_MAX_STR);
-        devices[info] = NULL;
-        deviceConnected(&info);
-        deviceStateChanged(&info, 0);
+        devices[info] = NULL;        
 
         freenect_device* dev;
         if (freenect_open_device(m_ctx, &dev, i) == 0)
@@ -262,6 +260,9 @@ namespace FreenectDriver
           info.usbVendorId = dev->usb_cam.VID;
           info.usbProductId = dev->usb_cam.PID;
           freenect_close_device(dev);
+          
+          deviceConnected(&info);
+          deviceStateChanged(&info, 0);
         }
         else
         {


### PR DESCRIPTION
Publishing the VID and PID from libfreenect to OpenNI2 seems to not work when the callbacks are called before setting them in the OniDeviceInfo struct. The values were floating.