### PR TITLE
Changing download server from microsoft to digiex

### DIFF
--- a/src/fwfetcher.py
+++ b/src/fwfetcher.py
@@ -576,7 +576,7 @@ if __name__ == "__main__":
         target = sys.argv[1]
     if not os.path.isfile(target):
         fw = getFileOrURL("SystemUpdate.zip",
-                          "https://www.xbox.com/system-update-usb")
+                          "https://download.digiex.net/Consoles/Xbox360/Dashboards/SystemUpdate_17559_USB.zip")
         pirs = extractPirsFromZip(fw)
 
         lang = ["English", "Japanese", "German", "French", "Spanish",


### PR DESCRIPTION
microsoft has removed the xbox 360 firmware files
digiex is also a very reliable source for downloading xbox 360 mods, firmware and all other stuff, i thought it would be a good alternative