### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ Alternately, firmware for Kinect model 1414 can be downloaded automatically by s
 
 Note that firmware may not be legal to redistribute in your jurisdiction!
 
+## Install and build instructions via vcpkg
+----------------------------------------
+You can download and install libfreenect using the vcpkg(https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install libfreenect
+
+The libfreenect port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request(https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## OSX
 
 If you don't have a package manager, install [Homebrew](http://brew.sh/).


### PR DESCRIPTION
Libfreenect is available as a port in vcpkg, a C++ library manager that simplifies installation for libfreenect and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build libfreenect, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.