### PR TITLE
build(examples): modernize opengl imports to close #658 and close #661

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,8 @@
 # Packages needed for examples
 ######################################################################################
 
+cmake_minimum_required(VERSION 3.8.2)
+
 # These examples have no external dependencies and should always build.
 add_executable(freenect-camtest camtest.c)
 add_executable(freenect-wavrecord wavrecord.c)
@@ -12,6 +14,7 @@ install(TARGETS freenect-camtest freenect-wavrecord
 
 # Most viewers need pthreads and GLUT.
 set(THREADS_USE_PTHREADS_WIN32 true)
+set(OpenGL_GL_PREFERENCE "GLVND")
 find_package(Threads)
 find_package(OpenGL)
 find_package(GLUT)
@@ -25,11 +28,11 @@ if (Threads_FOUND AND OPENGL_FOUND AND GLUT_FOUND)
   add_executable(freenect-chunkview chunkview.c)
   add_executable(freenect-micview micview.c)
 
-  target_link_libraries(freenect-glview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
-  target_link_libraries(freenect-regview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
-  target_link_libraries(freenect-hiview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
-  target_link_libraries(freenect-chunkview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
-  target_link_libraries(freenect-micview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
+  target_link_libraries(freenect-glview freenect OpenGL::GL GLUT::GLUT ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
+  target_link_libraries(freenect-regview freenect OpenGL::GL GLUT::GLUT ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
+  target_link_libraries(freenect-hiview freenect OpenGL::GL GLUT::GLUT ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
+  target_link_libraries(freenect-chunkview freenect OpenGL::GL GLUT::GLUT ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
+  target_link_libraries(freenect-micview freenect OpenGL::GL GLUT::GLUT ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
 
   install(TARGETS freenect-glview freenect-regview freenect-hiview freenect-chunkview freenect-micview
           DESTINATION bin)
@@ -51,7 +54,7 @@ if (BUILD_C_SYNC)
   if (OPENGL_FOUND AND GLUT_FOUND)
     include_directories(${OPENGL_INCLUDE_DIR} ${GLUT_INCLUDE_DIR})
     add_executable(freenect-glpclview glpclview.c)
-    target_link_libraries(freenect-glpclview freenect_sync ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${MATH_LIB})
+    target_link_libraries(freenect-glpclview freenect_sync OpenGL::GL OpenGL::GLU GLUT::GLUT ${MATH_LIB})
     install(TARGETS freenect-glpclview
             DESTINATION bin)
   endif ()

--- a/wrappers/cpp/CMakeLists.txt
+++ b/wrappers/cpp/CMakeLists.txt
@@ -5,6 +5,7 @@ install(FILES libfreenect.hpp
 
 if (BUILD_EXAMPLES)
   set(THREADS_USE_PTHREADS_WIN32 true)
+  set(OpenGL_GL_PREFERENCE "GLVND")
   find_package(Threads)
   find_package(OpenGL)
   find_package(GLUT)
@@ -18,8 +19,8 @@ if (BUILD_EXAMPLES)
     target_compile_features(freenect-cppview PUBLIC cxx_std_11)
     target_compile_features(freenect-cpp_pcview PUBLIC cxx_std_11)
 
-    target_link_libraries(freenect-cppview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
-    target_link_libraries(freenect-cpp_pcview freenect ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
+    target_link_libraries(freenect-cppview freenect OpenGL::GL OpenGL::GLU GLUT::GLUT ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
+    target_link_libraries(freenect-cpp_pcview freenect OpenGL::GL OpenGL::GLU GLUT::GLUT ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
 
     install(TARGETS freenect-cppview freenect-cpp_pcview
             DESTINATION bin)


### PR DESCRIPTION
Now cmake recommends `IMPORTED` targets for [OpenGL](https://cmake.org/cmake/help/v3.8/module/FindOpenGL.html) and [GLUT](https://cmake.org/cmake/help/v3.8/module/FindGLUT.html) so switch to those for future compatibility.  Also `set(OpenGL_GL_PREFERENCE "GLVND")` to silence warnings in case multiple OpenGL implementations are installed.