### PR TITLE
Added manual exposure settings

### DIFF
--- a/examples/glview.c
+++ b/examples/glview.c
@@ -217,6 +217,8 @@ void keyPressed(unsigned char key, int x, int y)
 	if (key == 'e') {
 		static freenect_flag_value auto_exposure = FREENECT_ON;
 		freenect_set_flag(f_dev, FREENECT_AUTO_EXPOSURE, auto_exposure);
+		freenect_set_flag(f_dev, FREENECT_AUTO_FLICKER, auto_exposure);
+		freenect_set_flag(f_dev, FREENECT_AUTO_WHITE_BALANCE, auto_exposure);
 		auto_exposure = auto_exposure ? FREENECT_OFF : FREENECT_ON;
 	}
 	if (key == 'b') {

--- a/include/libfreenect.h
+++ b/include/libfreenect.h
@@ -110,6 +110,7 @@ typedef enum {
 typedef enum {
 	// values written to the CMOS register
 	FREENECT_AUTO_EXPOSURE      = 1 << 14,
+	FREENECT_AUTO_FLICKER       = 1 << 7,
 	FREENECT_AUTO_WHITE_BALANCE = 1 << 1,
 	FREENECT_RAW_COLOR          = 1 << 4,
 	// arbitrary bitfields to support flag combination
@@ -669,6 +670,34 @@ FREENECTAPI int freenect_set_depth_mode(freenect_device* dev, const freenect_fra
  * @return 0 on success, < 0 if error
  */
 FREENECTAPI int freenect_set_flag(freenect_device *dev, freenect_flag flag, freenect_flag_value value);
+
+/**
+ * Get the current exposure in microseconds
+ *
+ * @param dev Device to set exposure
+ * @param time_us exposure time in microseconds
+ *
+ * @return 0 on success, < 0 if error
+ */
+FREENECTAPI int freenect_get_exposure(freenect_device *dev, int *time_us);
+
+/**
+ * Sets a static exposure time in microseconds
+ * note: you must turn off auto-exposure before calling this function
+ *
+ * Sample usage with 33.333ms exposure:
+ *
+ *   freenect_set_flag(fn_dev, FREENECT_AUTO_EXPOSURE, FREENECT_OFF);
+ *   freenect_set_flag(fn_dev, FREENECT_AUTO_FLICKER, FREENECT_OFF);
+ *   freenect_set_flag(fn_dev, FREENECT_AUTO_WHITE_BALANCE, FREENECT_OFF);
+ *   freenect_set_exposure(fn_dev, 33333);
+ *
+ * @param dev Device to set exposure
+ * @param time_us exposure time in microseconds
+ *
+ * @return 0 on success, < 0 if error
+ */
+FREENECTAPI int freenect_set_exposure(freenect_device *dev, int time_us);
 
 /**
  * Returns the brightness of the IR sensor.

--- a/src/freenect_internal.h
+++ b/src/freenect_internal.h
@@ -148,6 +148,12 @@ static inline int32_t fn_le32s(int32_t s)
 #define PID_K4W_AUDIO_ALT_1 0x02c3
 #define PID_K4W_AUDIO_ALT_2 0x02bb
 
+// Conversion from shutter width to exposure in microseconds
+// Measured using camtest.c with various very long exposure times
+// TODO: calculate this from camera registers instead of magic numbers
+#define SHUTTER_WIDTH_TO_EXP_RGB 54.21
+#define SHUTTER_WIDTH_TO_EXP_YUV 63.25
+
 typedef struct {
 	int running;
 	uint8_t flag;


### PR DESCRIPTION
Should fix or at least begin a fix for #386 / #387, and maybe other issues even.

Tested on Kinect 1414, I measured the following video capture times using camtest.c by comparing timestamps and dividing by 60MHz. By default the timestamps are 33.333ms apart.

    RGB Mode (30Hz)
    10000 -> 0.54208s
    20000 -> 1.08416s
    30000 -> 1.62625s

0.05421 x 10000 -> time in ms

    YUV Mode (15Hz)
    10000 -> 0.6325s
    20000 -> 1.265s
    30000 -> 1.8975s

0.06325 x 10000 -> time in ms

As for how I knew which register, I think people might be glad to see this document:
https://dlscorp.com/wp-content/uploads/2019/03/MT9M112_DS_full.pdf

Which I think is the correct datasheet for the MT9M112 that the Kinect v1 uses.
There are a few values related to exposure (shutter width, shutter delay, extra delay, blanking, etc), but my measurements didn't seem to have a constant offset, so I only use `shutter_width * MEASURED_CONSTANT`