### PR TITLE
Use the recommended way to integrate Cython and NumPy

### DIFF
--- a/wrappers/python/freenect.pyx
+++ b/wrappers/python/freenect.pyx
@@ -27,7 +27,6 @@ import numpy as np
 cimport numpy as npc
 
 cdef extern from "numpy/arrayobject.h":
-    void import_array()
     cdef object PyArray_SimpleNewFromData(int nd, npc.npy_intp *dims,
                                            int typenum, void *data)
 
@@ -455,7 +454,7 @@ def base_runloop(CtxPtr ctx, body=None):
     except Kill:
         pass
 
-import_array()
+npc.import_array()
 
 cdef object _depth_cb_np(void *data, freenect_frame_mode *mode):
     cdef npc.npy_intp dims[2]


### PR DESCRIPTION
This follows the example code in
<https://cython.readthedocs.io/en/latest/src/tutorial/numpy.html#adding-types>.

The previous version results in an int-conversion error with current compilers:

```
…-build/wrappers/python/freenect3.c:16598:3: error: returning ‘void *’ from a function with return type ‘int’ makes integer from pointer without a cast
16598 |   import_array();
      |   ^~~~~~~~~~~~
```

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
